### PR TITLE
Fix for incorrect expiry time

### DIFF
--- a/src/components/TransactionStatus/TransactionStatus.tsx
+++ b/src/components/TransactionStatus/TransactionStatus.tsx
@@ -85,7 +85,7 @@ const WaitingTransaction: React.FC<WaitingTransactionProps> = props => {
   }, [status, onClose])
 
   // @ts-ignore
-  const { name, target, lockupDuration } = props
+  const { name, target } = props
   const onCancelSubmit = useCallback(() => {
     if (name === PendingTransactionName.RemoveDelegator) {
       cancelTransaction(target)
@@ -95,7 +95,7 @@ const WaitingTransaction: React.FC<WaitingTransactionProps> = props => {
   }, [name, target, cancelTransaction])
   const { timeRemaining } = useTimeRemaining(
     props.lockupExpiryBlock,
-    lockupDuration
+    0 /* period - 0 because lockupExpiry has time period baked in */
   )
 
   return (

--- a/src/store/cache/protocol/hooks.ts
+++ b/src/store/cache/protocol/hooks.ts
@@ -199,7 +199,7 @@ export const useTimeRemaining = (block: number, period: number | null) => {
       if (currentBlock > targetBlock) {
         setTimeRemaining(0)
       } else {
-        setTimeRemaining((targetBlock - currentBlock) * averageBlockTime)
+        setTimeRemaining((targetBlock - currentBlock) * averageBlockTime * 1000)
       }
     }
   }, [averageBlockTime, currentBlock, block, period, targetBlock])


### PR DESCRIPTION
Tried to update SP deployer cut and I ran into two bugs

1. The time until the lockup ended had the wrong units, it kept showing like 28 minutes and kept resetting itself to 28 every so often when it should have been in days. That's because the useTimeRemaining hook returns seconds, but all the functions in format.ts require ms, so I multiplied by 1000 while setting timeRemaining. I tried to check all uses of timeRemaining (like useProposalTimeRemaining in Proposal.tsx and that calls a function that requires ms too, but I may have missed something.

2. After i fixed 1, I noticed the time period was off. It was 18 days instead of around 9 days. The reason for that I believe is useTimeRemaining takes in `block`, `period` and calculates `targetBlock`. However, the `block` being passed in is the expiry block which already has `period` baked into it, so we shouldn't add a `period` to it. Essentially it was double counting.

Tested against Ropsten
<img width="630" alt="Audius___Protocol_Dashboard" src="https://user-images.githubusercontent.com/295938/97770923-17ef8f80-1b0e-11eb-872d-bb4dcb9dcbce.png">
