### PR TITLE
Fix metamask infinite reload bug

### DIFF
--- a/src/services/Audius/setup.ts
+++ b/src/services/Audius/setup.ts
@@ -34,6 +34,9 @@ export async function setup(this: AudiusClient): Promise<void> {
     this.isViewOnly = true
     this.libs = await configureReadOnlyLibs()
   } else {
+    // Turn off auto refresh (this causes infinite reload loops)
+    window.ethereum.autoRefreshOnNetworkChange = false
+
     // Metamask is installed
     window.web3 = new Web3(window.ethereum)
     try {
@@ -60,6 +63,7 @@ export async function setup(this: AudiusClient): Promise<void> {
         if (!this.libs) {
           this.libs = await configureReadOnlyLibs()
           this.isAccountMisconfigured = true
+          this.hasValidAccount = false
         }
       }
     } catch (err) {


### PR DESCRIPTION
https://docs.metamask.io/guide/ethereum-provider.html#ethereum-autorefreshonnetworkchange
I believe this is super buggy and with our existing event listener it's done the right way. Sometimes there's some race condition here.

Also tiny fix to prevent showing a button when metamask is misconfigured 

TESTED=Locally against prod