### PR TITLE
Fix charts

### DIFF
--- a/src/store/cache/analytics/hooks.ts
+++ b/src/store/cache/analytics/hooks.ts
@@ -115,9 +115,16 @@ const joinTimeSeriesDatasets = (datasets: TimeSeriesRecord[][]) => {
   const joined: TimeSeriesRecord[] = []
 
   // Joined dataset should be of length "max" of each child dataset
-  const maxLength = Math.max(...datasets.map(d => d.length))
+  let maxLength = 0
+  let maxIndex = 0
+  datasets.forEach((dataset, i) => {
+    if (dataset.length > maxLength) {
+      maxLength = dataset.length
+      maxIndex = i
+    }
+  })
   for (let i = 0; i < maxLength; ++i) {
-    const { timestamp } = datasets[0][i]
+    const { timestamp } = datasets[maxIndex][i]
     let count: number = 0
     let unique_count: number = 0
     datasets.forEach(dataset => {


### PR DESCRIPTION
Fixes charts where the first item in the dataset is not of max length.

The datasets we get here are (dumbed down)

1. [{ts: 10, count: 10}, {ts: 9, count: 10}]
2. [{ts: 10, count: 5}, {ts: 9, count: 5}, {ts: 8, count: 4}]

The joined dataset should be
[{ts: 10, count: 15}, {ts: 9, count: 15}, {ts: 8, count: 4}]

If we "join" these datasets with #2 first, everything's cool, but if we join with #1 first, we end up not getting all the timestamps

<img width="1078" alt="Screen Shot 2020-11-18 at 4 00 03 PM" src="https://user-images.githubusercontent.com/2731362/99602895-20bddd80-29b7-11eb-840d-4697152a435c.png">
