### PR TITLE
Consume optimized endpoints

### DIFF
--- a/src/components/LineChart/LineChart.tsx
+++ b/src/components/LineChart/LineChart.tsx
@@ -24,7 +24,7 @@ export enum DateFormatter {
   MONTH
 }
 
-const getData = (data: number[], labels: string[]) => {
+const getData = (data: number[], labels: string[], showLeadingDay: boolean) => {
   const common = {
     fill: false,
     lineTension: 0.2,
@@ -44,28 +44,38 @@ const getData = (data: number[], labels: string[]) => {
     pointRadius: 0,
     pointHitRadius: 8
   }
-  const solidLine = (data.slice(0, -1) as (number | undefined)[]).concat([
-    undefined
-  ])
-  const dottedLine = new Array(Math.max(data.length - 2, 0))
-    .fill(undefined)
-    .concat(data.slice(-2))
-  return {
-    labels,
-    datasets: [
-      {
-        ...common,
-        label: 'past',
-        data: solidLine,
-        borderDash: []
-      },
+  let solidLine = (data.slice(0, -1) as (number | undefined)[])
+  if (showLeadingDay) {
+    solidLine = solidLine.concat([undefined])
+  }
+
+  const datasets = [{
+    ...common,
+    label: 'past',
+    data: solidLine,
+    borderDash: [] as number[]
+  }]
+
+  if (showLeadingDay) {
+    const dottedLine = new Array(Math.max(data.length - 2, 0))
+      .fill(undefined)
+      .concat(data.slice(-2))
+
+    datasets.push(
       {
         ...common,
         label: 'current',
         data: dottedLine,
         borderDash: [2, 6]
       }
-    ]
+    )
+  }
+
+  const newLabels = showLeadingDay ? labels : labels.slice(0, -1)
+
+  return {
+    labels: newLabels,
+    datasets,
   }
 }
 
@@ -171,7 +181,7 @@ const getOptions = (
 
       const { date, value } = tooltipModel.title[0] || {}
       const innerHtml = `
-        <div class='${styles.tooltipContainer}'> 
+        <div class='${styles.tooltipContainer}'>
           <div class='${styles.tooltipBody}'>
             <div class='${styles.tooltipDate}'>${date}</div>
             <div class='${styles.tooltipValue}'>${formatNumber(
@@ -233,6 +243,7 @@ type OwnProps = {
   selection?: Bucket
   onSelectOption?: (option: string) => void
   error?: boolean
+  showLeadingDay?: boolean
 }
 
 type LineChartProps = OwnProps
@@ -245,7 +256,8 @@ const LineChart: React.FC<LineChartProps> = ({
   options,
   selection,
   onSelectOption,
-  error
+  error,
+  showLeadingDay = false
 }) => {
   const dateFormatter =
     selection === Bucket.ALL_TIME || selection === Bucket.YEAR
@@ -274,7 +286,7 @@ const LineChart: React.FC<LineChartProps> = ({
           <Error text="Incomplete Data" />
         ) : data && labels ? (
           <Line
-            data={getData(data, labels)}
+            data={getData(data, labels, showLeadingDay)}
             options={getOptions(title, dateFormatter, tooltipTitle)}
           />
         ) : (

--- a/src/components/LineChart/LineChart.tsx
+++ b/src/components/LineChart/LineChart.tsx
@@ -44,38 +44,38 @@ const getData = (data: number[], labels: string[], showLeadingDay: boolean) => {
     pointRadius: 0,
     pointHitRadius: 8
   }
-  let solidLine = (data.slice(0, -1) as (number | undefined)[])
+  let solidLine = data.slice(0, -1) as (number | undefined)[]
   if (showLeadingDay) {
     solidLine = solidLine.concat([undefined])
   }
 
-  const datasets = [{
-    ...common,
-    label: 'past',
-    data: solidLine,
-    borderDash: [] as number[]
-  }]
+  const datasets = [
+    {
+      ...common,
+      label: 'past',
+      data: solidLine,
+      borderDash: [] as number[]
+    }
+  ]
 
   if (showLeadingDay) {
     const dottedLine = new Array(Math.max(data.length - 2, 0))
       .fill(undefined)
       .concat(data.slice(-2))
 
-    datasets.push(
-      {
-        ...common,
-        label: 'current',
-        data: dottedLine,
-        borderDash: [2, 6]
-      }
-    )
+    datasets.push({
+      ...common,
+      label: 'current',
+      data: dottedLine,
+      borderDash: [2, 6]
+    })
   }
 
   const newLabels = showLeadingDay ? labels : labels.slice(0, -1)
 
   return {
     labels: newLabels,
-    datasets,
+    datasets
   }
 }
 

--- a/src/store/cache/analytics/hooks.ts
+++ b/src/store/cache/analytics/hooks.ts
@@ -221,7 +221,12 @@ export function fetchPlays(
   nodes: DiscoveryProvider[]
 ): ThunkAction<void, AppState, Audius, Action<string>> {
   return async (dispatch, getState, aud) => {
-    const metric = await fetchTimeSeries('plays', bucket, nodes.slice(0, 1), true)
+    const metric = await fetchTimeSeries(
+      'plays',
+      bucket,
+      nodes.slice(0, 1),
+      true
+    )
     dispatch(setPlays({ metric, bucket }))
   }
 }
@@ -295,9 +300,12 @@ const getTrailingAPI = (endpoint: string) => async () => {
   } as CountRecord
 }
 
-const getTrailingAPILegacy = (endpoint: string, startTime: number) => async () => {
+const getTrailingAPILegacy = (
+  endpoint: string,
+  startTime: number
+) => async () => {
   const url = `${endpoint}/v1/metrics/routes?bucket_size=century&start_time=${startTime}`
-  const res =  await fetch(url)
+  const res = await fetch(url)
   if (!res.ok) {
     throw new Error(res.statusText)
   }
@@ -342,14 +350,18 @@ export function fetchTrailingApiCalls(
   }
 }
 
-const getTrailingTopApps = (endpoint: string, bucket: Bucket, limit: number) => async () => {
-  const bucketPaths: { [bucket: string]: string | undefined} = {
-    [Bucket.WEEK]: "week",
-    [Bucket.MONTH]: "month",
-    [Bucket.ALL_TIME]: "all_time"
+const getTrailingTopApps = (
+  endpoint: string,
+  bucket: Bucket,
+  limit: number
+) => async () => {
+  const bucketPaths: { [bucket: string]: string | undefined } = {
+    [Bucket.WEEK]: 'week',
+    [Bucket.MONTH]: 'month',
+    [Bucket.ALL_TIME]: 'all_time'
   }
   const bucketPath = bucketPaths[bucket]
-  if (!bucketPath) throw new Error("Invalid bucket")
+  if (!bucketPath) throw new Error('Invalid bucket')
   const url = `${endpoint}/v1/metrics/app_name/trailing/${bucketPath}?limit=${limit}`
   const res = await fetch(url)
   if (!res.ok) {
@@ -360,8 +372,11 @@ const getTrailingTopApps = (endpoint: string, bucket: Bucket, limit: number) => 
   return json
 }
 
-
-const getTopAppsLegacy = (endpoint: string, startTime: number, limit: number) => async () => {
+const getTopAppsLegacy = (
+  endpoint: string,
+  startTime: number,
+  limit: number
+) => async () => {
   const url = `${endpoint}/v1/metrics/app_name?start_time=${startTime}&limit=${limit}&include_unknown=true`
   const res = await fetch(url)
   if (!res.ok) {
@@ -385,16 +400,8 @@ export function fetchTopApps(
         nodes.map(async node => {
           try {
             const res = await performWithFallback(
-              getTrailingTopApps(
-                node.endpoint,
-                bucket,
-                limit
-              ),
-              getTopAppsLegacy(
-                node.endpoint,
-                startTime,
-                limit
-              )
+              getTrailingTopApps(node.endpoint, bucket, limit),
+              getTopAppsLegacy(node.endpoint, startTime, limit)
             )
             if (!res.data) return {}
             let apps: CountRecord = {}

--- a/src/store/cache/analytics/hooks.ts
+++ b/src/store/cache/analytics/hooks.ts
@@ -181,10 +181,9 @@ async function fetchTimeSeries(
 ) {
   const startTime = getStartTime(bucket, clampDays)
   let error = false
-  const nodez = [{ endpoint: 'http://localhost:5000'}]
   const datasets = (
     await Promise.all(
-      nodez.map(async node => {
+      nodes.map(async node => {
         try {
           const bucket_size = BUCKET_GRANULARITY_MAP[bucket]
           const url = `${node.endpoint}/v1/metrics/${route}?bucket_size=${bucket_size}&start_time=${startTime}`
@@ -296,7 +295,7 @@ const getTrailingAPI = (endpoint: string) => async () => {
   } as CountRecord
 }
 
-const getTrailingAPIFallback = (endpoint: string, startTime: number) => async () => {
+const getTrailingAPILegacy = (endpoint: string, startTime: number) => async () => {
   const url = `${endpoint}/v1/metrics/routes?bucket_size=century&start_time=${startTime}`
   const res =  await fetch(url)
   if (!res.ok) {
@@ -322,7 +321,7 @@ export function fetchTrailingApiCalls(
           try {
             const res = await performWithFallback(
               getTrailingAPI(node.endpoint),
-              getTrailingAPIFallback(node.endpoint, startTime)
+              getTrailingAPILegacy(node.endpoint, startTime)
             )
             return res
           } catch (e) {

--- a/src/utils/performWithFallback.ts
+++ b/src/utils/performWithFallback.ts
@@ -1,11 +1,13 @@
-
 /**
  * Tries to run `work`, falls back to `fallback` if `work` throws.
  *
  * @param work
  * @param fallback
  */
-export const performWithFallback = async <T>(work: () => Promise<T>, fallback: () => Promise<T>): Promise<T> => {
+export const performWithFallback = async <T>(
+  work: () => Promise<T>,
+  fallback: () => Promise<T>
+): Promise<T> => {
   try {
     const res = await work()
     return res

--- a/src/utils/performWithFallback.ts
+++ b/src/utils/performWithFallback.ts
@@ -10,14 +10,14 @@ export const performWithFallback = async <T>(work: () => Promise<T>, fallback: (
     const res = await work()
     return res
   } catch (e) {
-    console.log(`Call failed, falling back. ${e.message}`)
+    console.error(`Call failed, falling back. ${e.message}`)
   }
 
   try {
     const fall = await fallback()
     return fall
   } catch (e) {
-    console.log(`Fallback failed ${e.message}`)
+    console.error(`Fallback failed ${e.message}`)
     throw e
   }
 }

--- a/src/utils/performWithFallback.ts
+++ b/src/utils/performWithFallback.ts
@@ -1,0 +1,23 @@
+
+/**
+ * Tries to run `work`, falls back to `fallback` if `work` throws.
+ *
+ * @param work
+ * @param fallback
+ */
+export const performWithFallback = async <T>(work: () => Promise<T>, fallback: () => Promise<T>): Promise<T> => {
+  try {
+    const res = await work()
+    return res
+  } catch (e) {
+    console.log(`Call failed, falling back. ${e.message}`)
+  }
+
+  try {
+    const fall = await fallback()
+    return fall
+  } catch (e) {
+    console.log(`Fallback failed ${e.message}`)
+    throw e
+  }
+}


### PR DESCRIPTION
This PR contains a few changes:
- Consumes new `trailing` endpoints for API + App Name
- Optionally rounds to nearest day for time series data, so the final day has complete data
- Optionally removes leading day in Line charts
- Introduces fallback mechanism to support legacy endpoints

Also edited some existing endpoints to properly throw if `!res.ok`. 

Tested by running against local DP w/ snapshotted prod, hardcoding values as necessary