### PR TITLE
Move proposalHero from getTime to getHumanReadableTime

### DIFF
--- a/src/components/ProposalHero/ProposalHero.tsx
+++ b/src/components/ProposalHero/ProposalHero.tsx
@@ -5,8 +5,13 @@ import VoteMeter from 'components/VoteMeter'
 import ProposalStatusBadge from 'components/ProposalStatusBadge'
 import { Proposal, Outcome, Vote, Address, Status } from 'types'
 import Button, { ButtonType } from 'components/Button'
-import { leftPadZero, formatShortAud, formatWei, getDate } from 'utils/format'
-import { getHumanReadableTime } from 'utils/format'
+import {
+  leftPadZero,
+  formatShortAud,
+  formatWei,
+  getDate,
+  getHumanReadableTime
+} from 'utils/format'
 import { ReactComponent as IconThumbUp } from 'assets/img/iconThumbUp.svg'
 import { ReactComponent as IconThumbDown } from 'assets/img/iconThumbDown.svg'
 import ConfirmTransactionModal from 'components/ConfirmTransactionModal'

--- a/src/components/ProposalHero/ProposalHero.tsx
+++ b/src/components/ProposalHero/ProposalHero.tsx
@@ -5,13 +5,8 @@ import VoteMeter from 'components/VoteMeter'
 import ProposalStatusBadge from 'components/ProposalStatusBadge'
 import { Proposal, Outcome, Vote, Address, Status } from 'types'
 import Button, { ButtonType } from 'components/Button'
-import {
-  leftPadZero,
-  getTime,
-  formatShortAud,
-  formatWei,
-  getDate
-} from 'utils/format'
+import { leftPadZero, formatShortAud, formatWei, getDate } from 'utils/format'
+import { getHumanReadableTime } from 'utils/format'
 import { ReactComponent as IconThumbUp } from 'assets/img/iconThumbUp.svg'
 import { ReactComponent as IconThumbDown } from 'assets/img/iconThumbDown.svg'
 import ConfirmTransactionModal from 'components/ConfirmTransactionModal'
@@ -68,7 +63,7 @@ const VoteCTA: React.FC<VoteCTAProps> = ({
       <div className={styles.timeRemaining}>
         <div className={styles.title}>{messages.timeRemaining}</div>
         <div className={styles.time}>
-          {timeRemaining !== null && getTime(timeRemaining)}
+          {timeRemaining !== null && getHumanReadableTime(timeRemaining)}
         </div>
         <div className={styles.blocks}>
           <span>{`${messages.targetBlock}: ${targetBlock}`}</span>


### PR DESCRIPTION
The time remaining in the Governance hero was in the format hh:mm:ss, but it didn't account for times of multiple days. Switched that to consume the `getHumanReadableTime` function which is used in other places that displays the two largest units of time remaining.