### PR TITLE
Use active stake

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,9 +18,9 @@
       }
     },
     "@audius/libs": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@audius/libs/-/libs-1.1.0.tgz",
-      "integrity": "sha512-Z81taSM5IDFPf7AfcMkX4jLplixcOVPmhAbSY7jM3DUoMmfWZsjqCRrvslC2F4TjfKEviO/22Q5r+i9e6t9yBw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@audius/libs/-/libs-1.1.1.tgz",
+      "integrity": "sha512-7rZIUhdCoo6RHPnMr4JNfmwMB8EW8wFjWAWenVRcne2tKtecKTrg0v5tLurSbDZFiLwqTllHbAZoNymyfFrbxg==",
       "requires": {
         "@audius/hedgehog": "^1.0.8",
         "@ethersproject/solidity": "^5.0.5",
@@ -1423,9 +1423,9 @@
       }
     },
     "@ethersproject/sha2": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.0.4.tgz",
-      "integrity": "sha512-0yFhf1mspxAfWdXXoPtK94adUeu1R7/FzAa+DfEiZTc76sz/vHXf0LSIazoR3znYKFny6haBxME+usbvvEcF3A==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.0.6.tgz",
+      "integrity": "sha512-30gypDLkfkP5gE3llqi0jEuRV8m4/nvzeqmqMxiihZ7veFQHqDaGpyFeHzFim+qGeH9fq0lgYjavLvwW69+Fkw==",
       "requires": {
         "@ethersproject/bytes": "^5.0.4",
         "@ethersproject/logger": "^5.0.5",
@@ -1455,9 +1455,9 @@
       }
     },
     "@ethersproject/solidity": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.0.5.tgz",
-      "integrity": "sha512-DMFQ0ouXmNVoKWbGEUFGi8Urli4SJip9jXafQyFHWPRr5oJUqDVkNfwcyC37k+mhBG93k7qrYXCH2xJnGEOxHg==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.0.7.tgz",
+      "integrity": "sha512-dUevKUZ06p/VMLP/+cz4QUV+lA17NixucDJfm0ioWF0B3R0Lf+6wqwPchcqiAXlxkNFGIax7WNLgGMh4CkQ8iw==",
       "requires": {
         "@ethersproject/bignumber": "^5.0.7",
         "@ethersproject/bytes": "^5.0.4",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@audius/libs": "1.1.0",
+    "@audius/libs": "^1.1.1",
     "@audius/stems": "^0.2.5",
     "@reduxjs/toolkit": "^1.4.0",
     "chart.js": "^2.9.3",

--- a/src/components/DelegatesTable/DelegatesTable.tsx
+++ b/src/components/DelegatesTable/DelegatesTable.tsx
@@ -25,6 +25,7 @@ type Delegator = {
   name?: string
   address: Address
   amount: BN
+  activeAmount: BN
 }
 
 type OwnProps = {
@@ -46,7 +47,8 @@ const DelegatesTable: React.FC<DelegatesTableProps> = ({
     return {
       img: delegate.img,
       address: delegate.wallet,
-      amount: delegate.amount
+      amount: delegate.amount,
+      activeAmount: delegate.activeAmount
     }
   })
   const columns = [
@@ -66,9 +68,9 @@ const DelegatesTable: React.FC<DelegatesTableProps> = ({
         </div>
         <Tooltip
           className={clsx(styles.rowCol, styles.colAmount)}
-          text={formatWei(data.amount)}
+          text={formatWei(data.activeAmount)}
         >
-          {AudiusClient.displayShortAud(data.amount)}
+          {AudiusClient.displayShortAud(data.activeAmount)}
         </Tooltip>
       </div>
     )

--- a/src/components/DelegatorsTable/DelegatorsTable.tsx
+++ b/src/components/DelegatorsTable/DelegatorsTable.tsx
@@ -1,8 +1,9 @@
 import React, { useCallback } from 'react'
 import clsx from 'clsx'
+import BN from 'bn.js'
+
 import { usePushRoute } from 'utils/effects'
 import { useModalControls } from 'utils/hooks'
-
 import { accountPage } from 'utils/routes'
 import { useUser, useDelegators } from 'store/cache/user/hooks'
 
@@ -27,7 +28,8 @@ type Delegator = {
   img: string
   address: Address
   name: string | undefined
-  amount: string
+  amount: BN
+  activeAmount: BN
 }
 
 type OwnProps = {
@@ -49,7 +51,8 @@ const DelegatorsTable: React.FC<DelegatorsTableProps> = ({
       img: delegator.img,
       name: delegator.name,
       address: delegator.wallet,
-      amount: delegator.amount
+      amount: delegator.amount,
+      activeAmount: delegator.activeAmount
     }
   })
 
@@ -70,9 +73,9 @@ const DelegatorsTable: React.FC<DelegatorsTableProps> = ({
         </div>
         <Tooltip
           className={clsx(styles.rowCol, styles.colAmount)}
-          text={formatWei(data.amount)}
+          text={formatWei(data.activeAmount)}
         >
-          {AudiusClient.displayShortAud(data.amount)}
+          {AudiusClient.displayShortAud(data.activeAmount)}
         </Tooltip>
       </div>
     )

--- a/src/components/ProposalHero/ProposalHero.tsx
+++ b/src/components/ProposalHero/ProposalHero.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback, useEffect } from 'react'
+import { Utils } from '@audius/libs'
 
 import Paper from 'components/Paper'
 import VoteMeter from 'components/VoteMeter'
@@ -29,6 +30,7 @@ import { createStyles } from 'utils/mobile'
 import desktopStyles from './ProposalHero.module.css'
 import mobileStyles from './ProposalHeroMobile.module.css'
 import Loading from 'components/Loading'
+import getActiveStake from 'utils/activeStake'
 
 const styles = createStyles({ desktopStyles, mobileStyles })
 
@@ -58,10 +60,10 @@ const VoteCTA: React.FC<VoteCTAProps> = ({
   )
 
   const { status: userStatus, user: accountUser } = useAccountUser()
+  const activeStake = accountUser ? getActiveStake(accountUser) : Utils.toBN('0')
   const isUserStaker =
     userStatus === Status.Success &&
-    'totalStakedFor' in accountUser &&
-    !accountUser.totalStakedFor.isZero()
+    !activeStake.isZero()
 
   return (
     <div className={styles.voteCTA}>

--- a/src/components/ProposalHero/ProposalHero.tsx
+++ b/src/components/ProposalHero/ProposalHero.tsx
@@ -60,10 +60,10 @@ const VoteCTA: React.FC<VoteCTAProps> = ({
   )
 
   const { status: userStatus, user: accountUser } = useAccountUser()
-  const activeStake = accountUser ? getActiveStake(accountUser) : Utils.toBN('0')
-  const isUserStaker =
-    userStatus === Status.Success &&
-    !activeStake.isZero()
+  const activeStake = accountUser
+    ? getActiveStake(accountUser)
+    : Utils.toBN('0')
+  const isUserStaker = userStatus === Status.Success && !activeStake.isZero()
 
   return (
     <div className={styles.voteCTA}>

--- a/src/components/Proposals/Proposals.tsx
+++ b/src/components/Proposals/Proposals.tsx
@@ -52,10 +52,10 @@ export const NoProposals = ({ text }: { text: string }) => {
 const Proposals: React.FC<ProposalsProps> = () => {
   const { activeProposals, resolvedProposals } = useProposals()
   const { status: userStatus, user: accountUser } = useAccountUser()
-  const activeStake = accountUser ? getActiveStake(accountUser) : Utils.toBN('0')
-  const isUserStaker =
-    userStatus === Status.Success &&
-    !activeStake.isZero()
+  const activeStake = accountUser
+    ? getActiveStake(accountUser)
+    : Utils.toBN('0')
+  const isUserStaker = userStatus === Status.Success && !activeStake.isZero()
 
   return (
     <>

--- a/src/components/Proposals/Proposals.tsx
+++ b/src/components/Proposals/Proposals.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback } from 'react'
 import clsx from 'clsx'
+import { Utils } from '@audius/libs'
 
 import { useProposals } from 'store/cache/proposals/hooks'
 import Paper from 'components/Paper'
@@ -11,6 +12,7 @@ import Proposal from 'components/Proposal/Proposal'
 import Loading from 'components/Loading'
 import { useAccountUser } from 'store/account/hooks'
 import { Status } from 'types'
+import getActiveStake from 'utils/activeStake'
 
 const messages = {
   newProposal: 'New Proposal',
@@ -50,10 +52,10 @@ export const NoProposals = ({ text }: { text: string }) => {
 const Proposals: React.FC<ProposalsProps> = () => {
   const { activeProposals, resolvedProposals } = useProposals()
   const { status: userStatus, user: accountUser } = useAccountUser()
+  const activeStake = accountUser ? getActiveStake(accountUser) : Utils.toBN('0')
   const isUserStaker =
     userStatus === Status.Success &&
-    'totalStakedFor' in accountUser &&
-    !accountUser.totalStakedFor.isZero()
+    !activeStake.isZero()
 
   return (
     <>

--- a/src/components/TopAddressesTable/TopAddressesTable.tsx
+++ b/src/components/TopAddressesTable/TopAddressesTable.tsx
@@ -13,6 +13,7 @@ import { useTotalStaked } from 'store/cache/protocol/hooks'
 import { Status } from 'types'
 import { usePushRoute } from 'utils/effects'
 import { useIsMobile } from 'utils/hooks'
+import getActiveStake from 'utils/activeStake'
 
 const messages = {
   topAddresses: 'Top Addresses by Voting Weight',
@@ -61,23 +62,22 @@ const TopAddressesTable: React.FC<TopAddressesTableProps> = ({
   let columns = [{ title: 'Rank', className: styles.rankColumn }]
   if (!isMobile) {
     columns = columns.concat([
-      { title: 'Total Staked', className: styles.totalStakedColumn },
+      { title: 'Staked', className: styles.totalStakedColumn },
       { title: 'Vote Weight', className: styles.voteWeightColumn },
       { title: 'Proposals Voted', className: styles.proposalVotedColumn }
     ])
   }
 
   const data = users.map((user, idx) => {
-    const stakedAmount = user.delegatedTotal.add(
-      user.serviceProvider.deployerStake
-    )
-    const voteWeight = Audius.getBNPercentage(stakedAmount, totalStaked)
+    const activeStake = getActiveStake(user)
+
+    const voteWeight = Audius.getBNPercentage(activeStake, totalStaked)
     return {
       rank: idx + 1,
       img: user.image,
       name: user.name,
       wallet: user.wallet,
-      staked: stakedAmount,
+      staked: activeStake,
       voteWeight,
       proposedVotes: user.voteHistory.length
     }

--- a/src/containers/User/User.tsx
+++ b/src/containers/User/User.tsx
@@ -2,9 +2,10 @@ import React, { useEffect } from 'react'
 import clsx from 'clsx'
 import { RouteComponentProps } from 'react-router'
 import { matchPath } from 'react-router-dom'
+import { Utils } from '@audius/libs'
+
 import Page from 'components/Page'
 import Delegate from 'components/Delegate'
-
 import Timeline from 'components/Timeline'
 import UserStat from 'components/UserStat'
 import UserStakedStat from 'components/UserStakedStat'
@@ -34,6 +35,7 @@ import { useReplaceRoute } from 'utils/effects'
 import desktopStyles from './User.module.css'
 import mobileStyles from './UserMobile.module.css'
 import { createStyles } from 'utils/mobile'
+import getActiveStake from 'utils/activeStake'
 
 const styles = createStyles({ desktopStyles, mobileStyles })
 
@@ -86,6 +88,7 @@ const UserPage: React.FC<UserPageProps> = (props: UserPageProps) => {
   const services =
     ((user as Operator)?.discoveryProviders?.length ?? 0) +
     ((user as Operator)?.contentNodes?.length ?? 0)
+  const activeStake = user ? getActiveStake(user) : Utils.toBN('0')
 
   return (
     <Page
@@ -104,7 +107,7 @@ const UserPage: React.FC<UserPageProps> = (props: UserPageProps) => {
         />
         {isServiceProvider ? (
           <UserStat
-            staked={(user as Operator).totalStakedFor}
+            staked={activeStake}
             deployerCut={(user as Operator).serviceProvider.deployerCut}
             delegators={(user as Operator).delegators.length}
             totalDelegates={totalDelegates}

--- a/src/services/Audius/delegate.ts
+++ b/src/services/Audius/delegate.ts
@@ -82,6 +82,16 @@ export default class Delegate {
     return info
   }
 
+  async getTotalDelegatorStake(
+    delegator: Address
+  ): Promise<BigNumber> {
+    await this.aud.hasPermissions()
+    const info = await this.getContract().getTotalDelegatorStake(
+      delegator
+    )
+    return info
+  }
+
   async getTotalLockedDelegationForServiceProvider(
     serviceProvider: Address
   ): Promise<BigNumber> {

--- a/src/services/Audius/delegate.ts
+++ b/src/services/Audius/delegate.ts
@@ -82,13 +82,9 @@ export default class Delegate {
     return info
   }
 
-  async getTotalDelegatorStake(
-    delegator: Address
-  ): Promise<BigNumber> {
+  async getTotalDelegatorStake(delegator: Address): Promise<BigNumber> {
     await this.aud.hasPermissions()
-    const info = await this.getContract().getTotalDelegatorStake(
-      delegator
-    )
+    const info = await this.getContract().getTotalDelegatorStake(delegator)
     return info
   }
 

--- a/src/services/Audius/wrappers.ts
+++ b/src/services/Audius/wrappers.ts
@@ -34,7 +34,10 @@ export async function getUserDelegates(this: AudiusClient, delegator: Address) {
       )
       let activeAmount = amountDelegated
 
-      if (pendingUndelegateRequest.lockupExpiryBlock !==0 && pendingUndelegateRequest.target === sp) {
+      if (
+        pendingUndelegateRequest.lockupExpiryBlock !== 0 &&
+        pendingUndelegateRequest.target === sp
+      ) {
         activeAmount = activeAmount.sub(pendingUndelegateRequest.amount)
       }
 

--- a/src/services/Audius/wrappers.ts
+++ b/src/services/Audius/wrappers.ts
@@ -19,6 +19,9 @@ export async function getUserDelegates(this: AudiusClient, delegator: Address) {
   const increaseDelegateStakeEvents = await this.Delegate.getIncreaseDelegateStakeEvents(
     delegator
   )
+  const pendingUndelegateRequest = await this.Delegate.getPendingUndelegateRequest(
+    delegator
+  )
   let serviceProviders = increaseDelegateStakeEvents.map(e => e.serviceProvider)
   // @ts-ignore
   serviceProviders = [...new Set(serviceProviders)]
@@ -29,6 +32,11 @@ export async function getUserDelegates(this: AudiusClient, delegator: Address) {
         delegator,
         sp
       )
+      let activeAmount = amountDelegated
+
+      if (pendingUndelegateRequest.lockupExpiryBlock !==0 && pendingUndelegateRequest.target === sp) {
+        activeAmount = activeAmount.sub(pendingUndelegateRequest.amount)
+      }
 
       const profile = await get3BoxProfile(sp)
       let img = profile.image || getRandomDefaultImage(sp)
@@ -36,6 +44,7 @@ export async function getUserDelegates(this: AudiusClient, delegator: Address) {
       delegates.push({
         wallet: sp,
         amount: amountDelegated,
+        activeAmount,
         img,
         name: profile.name
       })

--- a/src/store/cache/user/hooks.ts
+++ b/src/store/cache/user/hooks.ts
@@ -159,10 +159,13 @@ const getDelegatorAmounts = async (
       delegatorWallet
     )
 
-    if (pendingUndelegateRequest.lockupExpiryBlock !==0 && pendingUndelegateRequest.target === wallet) {
+    if (
+      pendingUndelegateRequest.lockupExpiryBlock !== 0 &&
+      pendingUndelegateRequest.target === wallet
+    ) {
       activeAmount = activeAmount.sub(pendingUndelegateRequest.amount)
     }
-  
+
     const profile = await get3BoxProfile(wallet)
     let img = profile.image || getRandomDefaultImage(delegatorWallet)
 

--- a/src/store/cache/user/hooks.ts
+++ b/src/store/cache/user/hooks.ts
@@ -30,6 +30,7 @@ import {
   fetchContentNodes
 } from '../contentNode/hooks'
 import { useAccountUser } from 'store/account/hooks'
+import { GetPendingDecreaseStakeRequestResponse } from 'services/Audius/serviceProviderClient'
 
 type UseUsersProp = {
   sortBy?: SortUser
@@ -71,11 +72,17 @@ const getUserMetadata = async (wallet: Address, aud: Audius): Promise<User> => {
   const audToken = await aud.AudiusToken.balanceOf(wallet)
   const profile = await get3BoxProfile(wallet)
   const delegates = await aud.getUserDelegates(wallet)
+  const totalDelegatorStake = await aud.Delegate.getTotalDelegatorStake(wallet)
+  const pendingUndelegateRequest = await aud.Delegate.getPendingUndelegateRequest(
+    wallet
+  )
 
   const user = {
     wallet,
     image: getRandomDefaultImage(wallet),
     ...profile,
+    totalDelegatorStake,
+    pendingUndelegateRequest,
     audToken,
     delegates,
     events: []
@@ -90,6 +97,7 @@ const getServiceProviderMetadata = async (
 ): Promise<{
   serviceProvider: ServiceProvider
   discoveryProviders: Array<number>
+  pendingDecreaseStakeRequest: GetPendingDecreaseStakeRequestResponse
   contentNodes: Array<number>
   delegators: Array<Delegate>
   delegatedTotal: BN
@@ -112,10 +120,15 @@ const getServiceProviderMetadata = async (
     wallet,
     ServiceType.ContentNode
   )
+  const pendingDecreaseStakeRequest = await aud.ServiceProviderClient.getPendingDecreaseStakeRequest(
+    wallet
+  )
+
   const voteHistory = await aud.Governance.getVotesByAddress([wallet])
   return {
     serviceProvider,
     discoveryProviders,
+    pendingDecreaseStakeRequest,
     contentNodes,
     totalStakedFor,
     delegatedTotal,
@@ -130,6 +143,7 @@ const getDelegatorAmounts = async (
 ): Promise<Array<{
   wallet: Address
   amount: BN
+  activeAmount: BN
   name?: string
   img: string
 }>> => {
@@ -140,12 +154,22 @@ const getDelegatorAmounts = async (
       delegatorWallet,
       wallet
     )
+    let activeAmount = amountDelegated
+    const pendingUndelegateRequest = await aud.Delegate.getPendingUndelegateRequest(
+      delegatorWallet
+    )
+
+    if (pendingUndelegateRequest.lockupExpiryBlock !==0 && pendingUndelegateRequest.target === wallet) {
+      activeAmount = activeAmount.sub(pendingUndelegateRequest.amount)
+    }
+  
     const profile = await get3BoxProfile(wallet)
     let img = profile.image || getRandomDefaultImage(delegatorWallet)
 
     delegatorAmounts.push({
       wallet: delegatorWallet,
       amount: amountDelegated,
+      activeAmount,
       name: profile.name,
       img
     })

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,6 @@
 import BN from 'bn.js'
+import { GetPendingUndelegateRequestResponse } from 'services/Audius/delegate'
+import { GetPendingDecreaseStakeRequestResponse } from 'services/Audius/serviceProviderClient'
 
 // TODO: Type BigNumber
 export type BigNumber = any // BN
@@ -57,6 +59,7 @@ export type ServiceProvider = {
 export type Delegate = {
   wallet: Address
   amount: BN
+  activeAmount: BN
   name?: string
   img: string
 }
@@ -70,6 +73,8 @@ export type User = {
   name?: string
   image: string
   audToken: BigNumber
+  totalDelegatorStake: BigNumber
+  pendingUndelegateRequest: GetPendingUndelegateRequestResponse
   events: Array<EventID>
   delegates: Array<Delegate>
 }
@@ -77,6 +82,7 @@ export type User = {
 export type Operator = {
   serviceProvider: ServiceProvider
   discoveryProviders: Array<number>
+  pendingDecreaseStakeRequest: GetPendingDecreaseStakeRequestResponse
   contentNodes: Array<number>
   delegators: Array<Delegate>
   delegatedTotal: BN

--- a/src/utils/activeStake.ts
+++ b/src/utils/activeStake.ts
@@ -1,5 +1,5 @@
 import { Utils } from '@audius/libs'
-import { Operator, User } from "types"
+import { Operator, User } from 'types'
 
 /**
  * Calculates and returns active stake for address
@@ -16,7 +16,10 @@ export const getActiveStake = (user: User | Operator) => {
   let activeDelegator = Utils.toBN('0')
   if ('serviceProvider' in user) {
     const { deployerStake } = user.serviceProvider
-    const { amount: pendingDecreaseStakeAmount, lockupExpiryBlock } = user.pendingDecreaseStakeRequest
+    const {
+      amount: pendingDecreaseStakeAmount,
+      lockupExpiryBlock
+    } = user.pendingDecreaseStakeRequest
     if (lockupExpiryBlock !== 0) {
       activeDeployerStake = deployerStake.sub(pendingDecreaseStakeAmount)
     } else {
@@ -25,9 +28,11 @@ export const getActiveStake = (user: User | Operator) => {
   }
 
   if (user.pendingUndelegateRequest.lockupExpiryBlock !== 0) {
-    activeDelegator =  user.totalDelegatorStake.sub(user.pendingUndelegateRequest.amount)
+    activeDelegator = user.totalDelegatorStake.sub(
+      user.pendingUndelegateRequest.amount
+    )
   } else {
-    activeDelegator =  user.totalDelegatorStake
+    activeDelegator = user.totalDelegatorStake
   }
   return activeDelegator.add(activeDeployerStake)
 }

--- a/src/utils/activeStake.ts
+++ b/src/utils/activeStake.ts
@@ -13,7 +13,7 @@ import { Operator, User } from 'types'
 
 export const getActiveStake = (user: User | Operator) => {
   let activeDeployerStake = Utils.toBN('0')
-  let activeDelegator = Utils.toBN('0')
+  let activeDelegatorStake = Utils.toBN('0')
   if ('serviceProvider' in user) {
     const { deployerStake } = user.serviceProvider
     const {
@@ -28,13 +28,13 @@ export const getActiveStake = (user: User | Operator) => {
   }
 
   if (user.pendingUndelegateRequest.lockupExpiryBlock !== 0) {
-    activeDelegator = user.totalDelegatorStake.sub(
+    activeDelegatorStake = user.totalDelegatorStake.sub(
       user.pendingUndelegateRequest.amount
     )
   } else {
-    activeDelegator = user.totalDelegatorStake
+    activeDelegatorStake = user.totalDelegatorStake
   }
-  return activeDelegator.add(activeDeployerStake)
+  return activeDelegatorStake.add(activeDeployerStake)
 }
 
 export default getActiveStake

--- a/src/utils/activeStake.ts
+++ b/src/utils/activeStake.ts
@@ -1,0 +1,35 @@
+import { Utils } from '@audius/libs'
+import { Operator, User } from "types"
+
+/**
+ * Calculates and returns active stake for address
+ *
+ * Active stake = (active deployer stake + active delegator stake)
+ *      active deployer stake = (direct deployer stake - locked deployer stake)
+ *          locked deployer stake = amount of pending decreaseStakeRequest for address
+ *      active delegator stake = (total delegator stake - locked delegator stake)
+ *          locked delegator stake = amount of pending undelegateRequest for address
+ */
+
+export const getActiveStake = (user: User | Operator) => {
+  let activeDeployerStake = Utils.toBN('0')
+  let activeDelegator = Utils.toBN('0')
+  if ('serviceProvider' in user) {
+    const { deployerStake } = user.serviceProvider
+    const { amount: pendingDecreaseStakeAmount, lockupExpiryBlock } = user.pendingDecreaseStakeRequest
+    if (lockupExpiryBlock !== 0) {
+      activeDeployerStake = deployerStake.sub(pendingDecreaseStakeAmount)
+    } else {
+      activeDeployerStake = deployerStake
+    }
+  }
+
+  if (user.pendingUndelegateRequest.lockupExpiryBlock !== 0) {
+    activeDelegator =  user.totalDelegatorStake.sub(user.pendingUndelegateRequest.amount)
+  } else {
+    activeDelegator =  user.totalDelegatorStake
+  }
+  return activeDelegator.add(activeDeployerStake)
+}
+
+export default getActiveStake


### PR DESCRIPTION
Trello card - https://trello.com/c/XaUCCuvG/1727-priority-before-staking-rewards-delegators-should-be-able-to-vote-on-protocol-dashboard-dont-hide-button-also-on-dashboard-chang

## Description
There were contract changes that allow for users with `active stake` to create and vote on proposals which should be reflected in the dashboard. 
The contract [internal method](https://github.com/AudiusProject/audius-protocol/blob/master/eth-contracts/contracts/Governance.sol#L1094) for calculating active stake was replicated in the protocol dashboard. 
The dashboard show display active amounts (amount - pending decreases) instead of the current amount.

#### UI/UX Changes
* Allow users with active stake to create gov. proposals
* Allow users with active stake to vote on gov. proposals
* Update the top addresses table to show `active stake` instead of user stake
* Update the Delegates table to display active delegate stake (Amount the user delegates minus the pending decrease stake to the specific node operator)
* Update the Delegators table to display active delegate stake (note, same the above) 

#### Internal Changes
* Add the getTotalDelegatorStake binding from libs
* Update the User & Operator type models to hold more information to calculate active stake

  
NOTE: Waiting on libs version patch update for changes.
https://github.com/AudiusProject/audius-protocol/pull/1118
https://github.com/AudiusProject/audius-protocol/pull/1117


