### PR TITLE
Handle more events

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@audius/libs": "1.1.2",
+    "@audius/libs": "1.1.3",
     "@audius/stems": "^0.3.3",
     "@reduxjs/toolkit": "^1.4.0",
     "chart.js": "^2.9.3",

--- a/src/components/Timeline/TimelineEvent.module.css
+++ b/src/components/Timeline/TimelineEvent.module.css
@@ -1,5 +1,5 @@
 .container {
-  height: 103px;
+  min-height: 103px;
   width: 100%;
   border-top: 1px solid #3F415B;
   padding: 11px 52px 12px 32px;

--- a/src/components/Timeline/TimelineEvent.tsx
+++ b/src/components/Timeline/TimelineEvent.tsx
@@ -7,7 +7,7 @@ import Proposal from 'components/Proposal'
 import { useBlock } from 'store/cache/protocol/hooks'
 import { getDate, formatWei, formatAud, formatShortWallet } from 'utils/format'
 import { usePushRoute } from 'utils/effects'
-import { accountPage } from 'utils/routes'
+import { accountPage, contentNodePage, discoveryNodePage } from 'utils/routes'
 import { TICKER } from 'utils/consts'
 import Tooltip, { Position } from 'components/Tooltip'
 
@@ -202,6 +202,34 @@ const TimelineEvent: React.FC<TimelineEventProps> = ({
         <span className={styles.titleSpacingLeft}>
           {formatShortWallet(event.serviceProvider)}
         </span>
+      </span>
+    )
+    return (
+      <GenericTimelineEvent
+        onClick={onClick}
+        className={className}
+        header={header}
+        title={title}
+        blockNumber={event.blockNumber}
+      />
+    )
+  }
+
+  if ('registrationAction' in event) {
+    // did it register or deregister?
+    const didRegister = event.registrationAction === "register"
+
+    // is it discovery-node or creator-node
+    const isDiscovery = event.serviceType in ["discovery-node", "discovery-provider"]
+    const onClick = () => {
+      if (parentOnClick) parentOnClick()
+      const route = isDiscovery ? discoveryNodePage(event.spID) : contentNodePage(event.spID)
+      pushRoute(route)
+    }
+    const header = didRegister ? 'REGISTERED SERVICE' : 'DEREGISTERED SERVICE'
+    const title = (
+      <span className={styles.titleContainer}>
+        {`${didRegister ? "Registered" : "Deregistered"} ${event.serviceType} at ${event.endpoint}`}
       </span>
     )
     return (

--- a/src/components/Timeline/TimelineEvent.tsx
+++ b/src/components/Timeline/TimelineEvent.tsx
@@ -217,19 +217,24 @@ const TimelineEvent: React.FC<TimelineEventProps> = ({
 
   if ('registrationAction' in event) {
     // did it register or deregister?
-    const didRegister = event.registrationAction === "register"
+    const didRegister = event.registrationAction === 'register'
 
     // is it discovery-node or creator-node
-    const isDiscovery = event.serviceType in ["discovery-node", "discovery-provider"]
+    const isDiscovery =
+      event.serviceType in ['discovery-node', 'discovery-provider']
     const onClick = () => {
       if (parentOnClick) parentOnClick()
-      const route = isDiscovery ? discoveryNodePage(event.spID) : contentNodePage(event.spID)
+      const route = isDiscovery
+        ? discoveryNodePage(event.spID)
+        : contentNodePage(event.spID)
       pushRoute(route)
     }
     const header = didRegister ? 'REGISTERED SERVICE' : 'DEREGISTERED SERVICE'
     const title = (
       <span className={styles.titleContainer}>
-        {`${didRegister ? "Registered" : "Deregistered"} ${event.serviceType} at ${event.endpoint}`}
+        {`${didRegister ? 'Registered' : 'Deregistered'} ${
+          event.serviceType
+        } at ${event.endpoint}`}
       </span>
     )
     return (
@@ -246,41 +251,58 @@ const TimelineEvent: React.FC<TimelineEventProps> = ({
   if ('stakeAction' in event) {
     // TODO: need to handle cancel still
 
-    const INCREASE = "increase"
-    const DECREASE_REQUESTED = "decreaseRequested"
-    const DECREASE_EVALUATED = "decreaseEvaluated"
+    const INCREASE = 'increase'
+    const DECREASE_REQUESTED = 'decreaseRequested'
+    const DECREASE_EVALUATED = 'decreaseEvaluated'
     const action = event.stakeAction
 
     const onClick = () => {
       if (parentOnClick) parentOnClick()
     }
-    const header = action === INCREASE ? 'INCREASED STAKE' : (action === DECREASE_REQUESTED ? 'REQUESTED STAKE DECREASE' : 'DECREASED STAKE')
+    const header =
+      action === INCREASE
+        ? 'INCREASED STAKE'
+        : action === DECREASE_REQUESTED
+        ? 'REQUESTED STAKE DECREASE'
+        : 'DECREASED STAKE'
     const title = (
       <span className={styles.titleContainer}>
-        {`${action === INCREASE ? "Increased" : (action === DECREASE_REQUESTED) ? "Requested to decrease": "Decreased"} stake by`}
+        {`${
+          action === INCREASE
+            ? 'Increased'
+            : action === DECREASE_REQUESTED
+            ? 'Requested to decrease'
+            : 'Decreased'
+        } stake by`}
         <Tooltip
           position={Position.TOP}
-          text={formatWei(action === INCREASE ? event.increaseAmount : event.decreaseAmount)}
+          text={formatWei(
+            action === INCREASE ? event.increaseAmount : event.decreaseAmount
+          )}
           className={clsx(styles.titleSpacingLeft, styles.titleSpacingRight)}
         >
-          {formatAud(action === INCREASE ? event.increaseAmount : event.decreaseAmount)}
+          {formatAud(
+            action === INCREASE ? event.increaseAmount : event.decreaseAmount
+          )}
         </Tooltip>
-        {action === INCREASE  || action === DECREASE_EVALUATED ?
-          (
-            <>
-              {'to'}
-              <Tooltip
-                position={Position.TOP}
-                text={formatWei(event.newStakeAmount)}
-                className={clsx(styles.titleSpacingLeft, styles.titleSpacingRight)}
-              >
-                {formatAud(event.newStakeAmount)}
-              </Tooltip>
-              {TICKER}
-            </>
-          ) :
-          (TICKER)
-        }
+        {action === INCREASE || action === DECREASE_EVALUATED ? (
+          <>
+            {'to'}
+            <Tooltip
+              position={Position.TOP}
+              text={formatWei(event.newStakeAmount)}
+              className={clsx(
+                styles.titleSpacingLeft,
+                styles.titleSpacingRight
+              )}
+            >
+              {formatAud(event.newStakeAmount)}
+            </Tooltip>
+            {TICKER}
+          </>
+        ) : (
+          TICKER
+        )}
       </span>
     )
     return (

--- a/src/components/Timeline/TimelineEvent.tsx
+++ b/src/components/Timeline/TimelineEvent.tsx
@@ -243,6 +243,57 @@ const TimelineEvent: React.FC<TimelineEventProps> = ({
     )
   }
 
+  if ('stakeAction' in event) {
+    // TODO: need to handle cancel still
+
+    const INCREASE = "increase"
+    const DECREASE_REQUESTED = "decreaseRequested"
+    const DECREASE_EVALUATED = "decreaseEvaluated"
+    const action = event.stakeAction
+
+    const onClick = () => {
+      if (parentOnClick) parentOnClick()
+    }
+    const header = action === INCREASE ? 'INCREASED STAKE' : (action === DECREASE_REQUESTED ? 'REQUESTED STAKE DECREASE' : 'DECREASED STAKE')
+    const title = (
+      <span className={styles.titleContainer}>
+        {`${action === INCREASE ? "Increased" : (action === DECREASE_REQUESTED) ? "Requested to decrease": "Decreased"} stake by`}
+        <Tooltip
+          position={Position.TOP}
+          text={formatWei(action === INCREASE ? event.increaseAmount : event.decreaseAmount)}
+          className={clsx(styles.titleSpacingLeft, styles.titleSpacingRight)}
+        >
+          {formatAud(action === INCREASE ? event.increaseAmount : event.decreaseAmount)}
+        </Tooltip>
+        {action === INCREASE  || action === DECREASE_EVALUATED ?
+          (
+            <>
+              {'to'}
+              <Tooltip
+                position={Position.TOP}
+                text={formatWei(event.newStakeAmount)}
+                className={clsx(styles.titleSpacingLeft, styles.titleSpacingRight)}
+              >
+                {formatAud(event.newStakeAmount)}
+              </Tooltip>
+              {TICKER}
+            </>
+          ) :
+          (TICKER)
+        }
+      </span>
+    )
+    return (
+      <GenericTimelineEvent
+        onClick={onClick}
+        className={className}
+        header={header}
+        title={title}
+        blockNumber={event.blockNumber}
+      />
+    )
+  }
+
   if ('claimer' in event && 'rewards' in event) {
     const onClick = () => {
       if (parentOnClick) parentOnClick()

--- a/src/components/Timeline/TimelineEvent.tsx
+++ b/src/components/Timeline/TimelineEvent.tsx
@@ -248,6 +248,8 @@ const TimelineEvent: React.FC<TimelineEventProps> = ({
     )
   }
 
+  // stake actions can be
+  // increases, decreases requested/evaluated/(eventually cancelled)
   if ('stakeAction' in event) {
     // TODO: need to handle cancel still
 
@@ -258,6 +260,7 @@ const TimelineEvent: React.FC<TimelineEventProps> = ({
 
     const onClick = () => {
       if (parentOnClick) parentOnClick()
+      // do nothing for stake actions
     }
     const header =
       action === INCREASE

--- a/src/services/Audius/delegate.ts
+++ b/src/services/Audius/delegate.ts
@@ -208,6 +208,16 @@ export default class Delegate {
     return info
   }
 
+  async getReceiveDelegateDecreaseStakeEvents(
+    serviceProvider: Address
+  ): Promise<Array<DecreaseDelegateStakeEvent>> {
+    await this.aud.hasPermissions()
+    const info = await this.getContract().getDecreaseDelegateStakeEvents({
+      serviceProvider
+    })
+    return info
+  }
+
   async getClaimEvents(
     claimer: Address
   ): Promise<

--- a/src/services/Audius/delegate.ts
+++ b/src/services/Audius/delegate.ts
@@ -218,6 +218,16 @@ export default class Delegate {
     return info
   }
 
+  async getUndelegateStakeRequestedEvents(
+    serviceProvider: Address
+  ): Promise<Array<any>> {
+    await this.aud.hasPermissions()
+    const info = await this.getContract().getUndelegateStakeRequestedEvents({
+      serviceProvider
+    })
+    return info.map((event: any) => ({...event, undelegationStep: "requested"}))
+  }
+
   async getClaimEvents(
     claimer: Address
   ): Promise<

--- a/src/services/Audius/delegate.ts
+++ b/src/services/Audius/delegate.ts
@@ -225,7 +225,10 @@ export default class Delegate {
     const info = await this.getContract().getUndelegateStakeRequestedEvents({
       serviceProvider
     })
-    return info.map((event: any) => ({...event, undelegationStep: "requested"}))
+    return info.map((event: any) => ({
+      ...event,
+      undelegationStep: 'requested'
+    }))
   }
 
   async getClaimEvents(

--- a/src/services/Audius/serviceProviderClient.ts
+++ b/src/services/Audius/serviceProviderClient.ts
@@ -215,18 +215,20 @@ export default class ServiceProviderClient {
     })
     return events.map((event: any) => ({
       ...event,
-      registrationAction: "register"
+      registrationAction: 'register'
     }))
   }
 
   async getDeregisteredServiceProviderEvents(wallet: Address): Promise<any> {
     await this.aud.hasPermissions()
-    const events = await this.getContract().getDeregisteredServiceProviderEvents({
-      owner: wallet
-    })
+    const events = await this.getContract().getDeregisteredServiceProviderEvents(
+      {
+        owner: wallet
+      }
+    )
     return events.map((event: any) => ({
       ...event,
-      registrationAction: "deregister"
+      registrationAction: 'deregister'
     }))
   }
 
@@ -237,7 +239,7 @@ export default class ServiceProviderClient {
     })
     return events.map((event: any) => ({
       ...event,
-      stakeAction: "increase"
+      stakeAction: 'increase'
     }))
   }
 
@@ -248,7 +250,7 @@ export default class ServiceProviderClient {
     })
     return events.map((event: any) => ({
       ...event,
-      stakeAction: "decreaseEvaluated"
+      stakeAction: 'decreaseEvaluated'
     }))
   }
 
@@ -259,7 +261,7 @@ export default class ServiceProviderClient {
     })
     return events.map((event: any) => ({
       ...event,
-      stakeAction: "decreaseRequested"
+      stakeAction: 'decreaseRequested'
     }))
   }
 

--- a/src/services/Audius/serviceProviderClient.ts
+++ b/src/services/Audius/serviceProviderClient.ts
@@ -208,6 +208,30 @@ export default class ServiceProviderClient {
     return info
   }
 
+  async getRegisteredServiceProviderEvents(wallet: Address): Promise<any> {
+    await this.aud.hasPermissions()
+    const events = await this.getContract().getRegisteredServiceProviderEvents({
+      owner: wallet
+    })
+    console.log({events})
+    return events.map((event: any) => ({
+      ...event,
+      registrationAction: "register"
+    }))
+  }
+
+  async getDeregisteredServiceProviderEvents(wallet: Address): Promise<any> {
+    await this.aud.hasPermissions()
+    const events = await this.getContract().getDeregisteredServiceProviderEvents({
+      owner: wallet
+    })
+    console.log({events})
+    return events.map((event: any) => ({
+      ...event,
+      registrationAction: "deregister"
+    }))
+  }
+
   /* -------------------- Service Provider Write -------------------- */
 
   async registerWithDelegate(

--- a/src/services/Audius/serviceProviderClient.ts
+++ b/src/services/Audius/serviceProviderClient.ts
@@ -213,7 +213,6 @@ export default class ServiceProviderClient {
     const events = await this.getContract().getRegisteredServiceProviderEvents({
       owner: wallet
     })
-    console.log({events})
     return events.map((event: any) => ({
       ...event,
       registrationAction: "register"
@@ -225,10 +224,42 @@ export default class ServiceProviderClient {
     const events = await this.getContract().getDeregisteredServiceProviderEvents({
       owner: wallet
     })
-    console.log({events})
     return events.map((event: any) => ({
       ...event,
       registrationAction: "deregister"
+    }))
+  }
+
+  async getIncreasedStakeEvents(wallet: Address): Promise<any> {
+    await this.aud.hasPermissions()
+    const events = await this.getContract().getIncreasedStakeEvents({
+      owner: wallet
+    })
+    return events.map((event: any) => ({
+      ...event,
+      stakeAction: "increase"
+    }))
+  }
+
+  async getDecreasedStakeEvaluatedEvents(wallet: Address): Promise<any> {
+    await this.aud.hasPermissions()
+    const events = await this.getContract().getDecreasedStakeEvaluatedEvents({
+      owner: wallet
+    })
+    return events.map((event: any) => ({
+      ...event,
+      stakeAction: "decreaseEvaluated"
+    }))
+  }
+
+  async getDecreasedStakeRequestedEvents(wallet: Address): Promise<any> {
+    await this.aud.hasPermissions()
+    const events = await this.getContract().getDecreasedStakeRequestedEvents({
+      owner: wallet
+    })
+    return events.map((event: any) => ({
+      ...event,
+      stakeAction: "decreaseRequested"
     }))
   }
 

--- a/src/store/cache/timeline/hooks.ts
+++ b/src/store/cache/timeline/hooks.ts
@@ -60,8 +60,21 @@ export function fetchTimeline(
       aud.Delegate.getClaimEvents(wallet),
       aud.Delegate.getReceiveDelegationIncreaseEvents(wallet),
       aud.ServiceProviderClient.getRegisteredServiceProviderEvents(wallet),
-      aud.ServiceProviderClient.getDeregisteredServiceProviderEvents(wallet)
+      aud.ServiceProviderClient.getDeregisteredServiceProviderEvents(wallet),
+      aud.ServiceProviderClient.getIncreasedStakeEvents(wallet),
+      aud.ServiceProviderClient.getDecreasedStakeRequestedEvents(wallet),
     ])
+
+    // const increases = await aud.ServiceProviderClient.getIncreasedStakeEvents(wallet)
+    // const decreases = await aud.ServiceProviderClient.getDecreasedStakeEvaluatedEvents(wallet)
+    // const decreaseRequested = await aud.ServiceProviderClient.getDecreasedStakeRequestedEvents(wallet)
+    // console.log({increases, decreases, decreaseRequested})
+
+    // TODO: if I get around to these
+    const decreases = await aud.Delegate.getReceiveDelegateDecreaseStakeEvents(wallet)
+    const decreaseRequested = await aud.Delegate.getUndelegateStakeRequestedEvents(wallet)
+    console.log({decreases, decreaseRequested})
+
 
     // const registerEvents = await aud.ServiceProviderClient.getRegisteredServiceProviderEvents(wallet)
     // const deregisteredEvents = await aud.ServiceProviderClient.getDeregisteredServiceProviderEvents(wallet)

--- a/src/store/cache/timeline/hooks.ts
+++ b/src/store/cache/timeline/hooks.ts
@@ -58,8 +58,14 @@ export function fetchTimeline(
       aud.Delegate.getIncreaseDelegateStakeEvents(wallet),
       aud.Delegate.getDecreaseDelegateStakeEvents(wallet),
       aud.Delegate.getClaimEvents(wallet),
-      aud.Delegate.getReceiveDelegationIncreaseEvents(wallet)
+      aud.Delegate.getReceiveDelegationIncreaseEvents(wallet),
+      aud.ServiceProviderClient.getRegisteredServiceProviderEvents(wallet),
+      aud.ServiceProviderClient.getDeregisteredServiceProviderEvents(wallet)
     ])
+
+    // const registerEvents = await aud.ServiceProviderClient.getRegisteredServiceProviderEvents(wallet)
+    // const deregisteredEvents = await aud.ServiceProviderClient.getDeregisteredServiceProviderEvents(wallet)
+    // console.log({registerEvents})
 
     const timeline = combineEvents(...events).reverse()
     dispatch(setTimeline({ wallet, timeline }))

--- a/src/store/cache/timeline/hooks.ts
+++ b/src/store/cache/timeline/hooks.ts
@@ -62,23 +62,8 @@ export function fetchTimeline(
       aud.ServiceProviderClient.getRegisteredServiceProviderEvents(wallet),
       aud.ServiceProviderClient.getDeregisteredServiceProviderEvents(wallet),
       aud.ServiceProviderClient.getIncreasedStakeEvents(wallet),
-      aud.ServiceProviderClient.getDecreasedStakeRequestedEvents(wallet),
+      aud.ServiceProviderClient.getDecreasedStakeRequestedEvents(wallet)
     ])
-
-    // const increases = await aud.ServiceProviderClient.getIncreasedStakeEvents(wallet)
-    // const decreases = await aud.ServiceProviderClient.getDecreasedStakeEvaluatedEvents(wallet)
-    // const decreaseRequested = await aud.ServiceProviderClient.getDecreasedStakeRequestedEvents(wallet)
-    // console.log({increases, decreases, decreaseRequested})
-
-    // TODO: if I get around to these
-    const decreases = await aud.Delegate.getReceiveDelegateDecreaseStakeEvents(wallet)
-    const decreaseRequested = await aud.Delegate.getUndelegateStakeRequestedEvents(wallet)
-    console.log({decreases, decreaseRequested})
-
-
-    // const registerEvents = await aud.ServiceProviderClient.getRegisteredServiceProviderEvents(wallet)
-    // const deregisteredEvents = await aud.ServiceProviderClient.getDeregisteredServiceProviderEvents(wallet)
-    // console.log({registerEvents})
 
     const timeline = combineEvents(...events).reverse()
     dispatch(setTimeline({ wallet, timeline }))


### PR DESCRIPTION
Playing fast and loose with the types here, this definitely needs cleanup.

New events:
- Service Registration + Deregistration
- SP Increase/decrease request/decrease stake 

Not yet handled:
- Delegators requesting/evaluating/cancelling decrease stake (we do handle increase)
- SP decrease cancel stake event