### PR TITLE
Add delegators to top addresses

### DIFF
--- a/src/components/TopAddressesTable/TopAddressesTable.tsx
+++ b/src/components/TopAddressesTable/TopAddressesTable.tsx
@@ -8,7 +8,7 @@ import Table from 'components/Table'
 import Tooltip from 'components/Tooltip'
 import { formatShortWallet, formatWeight, formatWei } from 'utils/format'
 
-import { useServiceProviders } from 'store/cache/user/hooks'
+import { useUsers } from 'store/cache/user/hooks'
 import { useTotalStaked } from 'store/cache/protocol/hooks'
 import { Status } from 'types'
 import { usePushRoute } from 'utils/effects'
@@ -56,7 +56,7 @@ const TopAddressesTable: React.FC<TopAddressesTableProps> = ({
     [pushRoute]
   )
 
-  const { status, users } = useServiceProviders({ limit })
+  const { status, users } = useUsers({ limit })
   const totalStaked = useTotalStaked()
 
   let columns = [{ title: 'Rank', className: styles.rankColumn }]

--- a/src/store/cache/user/hooks.ts
+++ b/src/store/cache/user/hooks.ts
@@ -14,8 +14,7 @@ import {
   ServiceType,
   Operator,
   Delegate,
-  ServiceProvider,
-  VoteEvent
+  ServiceProvider
 } from 'types'
 import Audius from 'services/Audius'
 import { AppState } from 'store/types'
@@ -31,6 +30,7 @@ import {
 } from '../contentNode/hooks'
 import { useAccountUser } from 'store/account/hooks'
 import { GetPendingDecreaseStakeRequestResponse } from 'services/Audius/serviceProviderClient'
+import getActiveStake from 'utils/activeStake'
 
 type UseUsersProp = {
   sortBy?: SortUser
@@ -42,20 +42,19 @@ export const getStatus = (state: AppState) => state.cache.user.status
 export const getUser = (wallet: Address) => (state: AppState) =>
   state.cache.user.accounts[wallet]
 
-export const getServiceProviders = ({ sortBy, limit }: UseUsersProp) => (
+export const getUsers = ({ sortBy, limit }: UseUsersProp) => (
   state: AppState
 ) => {
   const userAccounts = state.cache.user.accounts
   let accounts: (User | Operator)[] = Object.values(userAccounts)
 
   const filterFunc = (user: User | Operator) => {
-    if ('serviceProvider' in user) return true
-    return false
+    return true
   }
 
   const sortFunc = (u1: Operator, u2: Operator) => {
-    let u1Total = u1.delegatedTotal.add(u1.serviceProvider.deployerStake)
-    let u2Total = u2.delegatedTotal.add(u2.serviceProvider.deployerStake)
+    let u1Total = getActiveStake(u1)
+    let u2Total = getActiveStake(u2)
     return u2Total.cmp(u1Total)
   }
 
@@ -76,6 +75,7 @@ const getUserMetadata = async (wallet: Address, aud: Audius): Promise<User> => {
   const pendingUndelegateRequest = await aud.Delegate.getPendingUndelegateRequest(
     wallet
   )
+  const voteHistory = await aud.Governance.getVotesByAddress([wallet])
 
   const user = {
     wallet,
@@ -85,6 +85,7 @@ const getUserMetadata = async (wallet: Address, aud: Audius): Promise<User> => {
     pendingUndelegateRequest,
     audToken,
     delegates,
+    voteHistory,
     events: []
   }
 
@@ -102,7 +103,6 @@ const getServiceProviderMetadata = async (
   delegators: Array<Delegate>
   delegatedTotal: BN
   totalStakedFor: BN
-  voteHistory: Array<VoteEvent>
 }> => {
   const totalStakedFor = await aud.Staking.totalStakedFor(wallet)
   const delegatedTotal = await aud.Delegate.getTotalDelegatedToServiceProvider(
@@ -124,7 +124,6 @@ const getServiceProviderMetadata = async (
     wallet
   )
 
-  const voteHistory = await aud.Governance.getVotesByAddress([wallet])
   return {
     serviceProvider,
     discoveryProviders,
@@ -132,8 +131,7 @@ const getServiceProviderMetadata = async (
     contentNodes,
     totalStakedFor,
     delegatedTotal,
-    delegators,
-    voteHistory
+    delegators
   }
 }
 
@@ -199,7 +197,7 @@ function fetchUsers(): ThunkAction<void, AppState, Audius, Action<string>> {
     // @ts-ignore
     serviceProviderWallets = [...new Set(serviceProviderWallets)]
 
-    const users: { [wallet: string]: Operator } = {}
+    const users: { [wallet: string]: User | Operator } = {}
     await Promise.all(
       serviceProviderWallets.map(async wallet => {
         const user = await getUserMetadata(wallet, aud)
@@ -210,6 +208,26 @@ function fetchUsers(): ThunkAction<void, AppState, Audius, Action<string>> {
         }
       })
     )
+
+    // Get all delegators that are not service operators
+    let delegators = Object.keys(users).reduce((delgators: string[], operatorWallet) => {
+      const operator = users[operatorWallet]
+      const operatorDelegators = (operator as Operator).delegators
+        .map((delegator) => delegator.wallet)
+        .filter(wallet => !(wallet in users))
+      return delgators.concat(operatorDelegators)
+    }, [])
+    // @ts-ignore
+    delegators = [...(new Set(delegators))]
+
+    await Promise.all(
+      delegators.map(async wallet => {
+        const user = await getUserMetadata(wallet, aud)
+        users[wallet] = user
+      })
+    )
+
+
     dispatch(
       setUsers({
         users,
@@ -252,9 +270,9 @@ export function fetchUser(
 }
 
 // -------------------------------- Hooks  --------------------------------
-export const useServiceProviders = ({ limit, sortBy }: UseUsersProp = {}) => {
+export const useUsers = ({ limit, sortBy }: UseUsersProp = {}) => {
   const status = useSelector(getStatus)
-  const users = useSelector(getServiceProviders({ limit, sortBy }))
+  const users = useSelector(getUsers({ limit, sortBy }))
 
   const dispatch = useDispatch()
   useEffect(() => {

--- a/src/store/cache/user/hooks.ts
+++ b/src/store/cache/user/hooks.ts
@@ -210,15 +210,18 @@ function fetchUsers(): ThunkAction<void, AppState, Audius, Action<string>> {
     )
 
     // Get all delegators that are not service operators
-    let delegators = Object.keys(users).reduce((delgators: string[], operatorWallet) => {
-      const operator = users[operatorWallet]
-      const operatorDelegators = (operator as Operator).delegators
-        .map((delegator) => delegator.wallet)
-        .filter(wallet => !(wallet in users))
-      return delgators.concat(operatorDelegators)
-    }, [])
+    let delegators = Object.keys(users).reduce(
+      (delgators: string[], operatorWallet) => {
+        const operator = users[operatorWallet]
+        const operatorDelegators = (operator as Operator).delegators
+          .map(delegator => delegator.wallet)
+          .filter(wallet => !(wallet in users))
+        return delgators.concat(operatorDelegators)
+      },
+      []
+    )
     // @ts-ignore
-    delegators = [...(new Set(delegators))]
+    delegators = [...new Set(delegators)]
 
     await Promise.all(
       delegators.map(async wallet => {
@@ -226,7 +229,6 @@ function fetchUsers(): ThunkAction<void, AppState, Audius, Action<string>> {
         users[wallet] = user
       })
     )
-
 
     dispatch(
       setUsers({

--- a/src/types.ts
+++ b/src/types.ts
@@ -77,6 +77,7 @@ export type User = {
   pendingUndelegateRequest: GetPendingUndelegateRequestResponse
   events: Array<EventID>
   delegates: Array<Delegate>
+  voteHistory: Array<VoteEvent>
 }
 
 export type Operator = {
@@ -87,7 +88,6 @@ export type Operator = {
   delegators: Array<Delegate>
   delegatedTotal: BN
   totalStakedFor: BN
-  voteHistory: Array<VoteEvent>
 } & User
 
 // Transaction


### PR DESCRIPTION
## Description
Add delegators to the top addresses by voting weight table

<img width="992" alt="Screen Shot 2020-12-17 at 11 02 11 AM" src="https://user-images.githubusercontent.com/7064122/102511888-535f0280-4057-11eb-90e6-51203c885bfc.png">

Note: I moved the vote history from the service operators to user because delegator users that are not service operators can now vote. 

Note: The fetchUsers method should take a good amount more time now because it has to fetch all delegators for all service operators.

Note: We should eventually normalize the cache be/ we now store delegator in the cache users and in the nested cache users's delegators array which should now just be a reference to the user in the cache.    
