### PR TITLE
Fix active stake component logic

### DIFF
--- a/src/components/TotalStakedStat/TotalStakedStat.tsx
+++ b/src/components/TotalStakedStat/TotalStakedStat.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { ReactNode } from 'react'
 import BN from 'bn.js'
 
 import { formatShortAud } from 'utils/format'
@@ -9,6 +9,7 @@ import Tooltip from 'components/Tooltip'
 import { formatWei } from 'utils/format'
 import getActiveStake from 'utils/activeStake'
 import styles from './TotalStakedStat.module.css'
+import { Status } from 'types'
 
 const messages = {
   staked: `Active Stake ${TICKER}`
@@ -19,18 +20,22 @@ type OwnProps = {}
 type TotalStakedStatProps = OwnProps
 
 const TotalStakedStat: React.FC<TotalStakedStatProps> = () => {
-  const { users } = useUsers()
+  const { status, users } = useUsers()
+  const isLoading = status === Status.Loading
 
-  const totalVotingPowerStake = users?.reduce((total, user) => {
-    const activeStake = getActiveStake(user)
-    return total.add(activeStake)
-  }, new BN('0'))
+  let stat: ReactNode = null
 
-  const stat = !totalVotingPowerStake.isZero() ? (
-    <Tooltip className={styles.stat} text={formatWei(totalVotingPowerStake)}>
+  if (users && !isLoading) {
+    const totalVotingPowerStake = users.reduce((total, user) => {
+      const activeStake = getActiveStake(user)
+      return total.add(activeStake)
+    }, new BN('0'))
+  
+    stat = <Tooltip className={styles.stat} text={formatWei(totalVotingPowerStake)}>
       {formatShortAud(totalVotingPowerStake)}
     </Tooltip>
-  ) : null
+  }
+
   return <Stat label={messages.staked} stat={stat} />
 }
 

--- a/src/components/TotalStakedStat/TotalStakedStat.tsx
+++ b/src/components/TotalStakedStat/TotalStakedStat.tsx
@@ -30,10 +30,12 @@ const TotalStakedStat: React.FC<TotalStakedStatProps> = () => {
       const activeStake = getActiveStake(user)
       return total.add(activeStake)
     }, new BN('0'))
-  
-    stat = <Tooltip className={styles.stat} text={formatWei(totalVotingPowerStake)}>
-      {formatShortAud(totalVotingPowerStake)}
-    </Tooltip>
+
+    stat = (
+      <Tooltip className={styles.stat} text={formatWei(totalVotingPowerStake)}>
+        {formatShortAud(totalVotingPowerStake)}
+      </Tooltip>
+    )
   }
 
   return <Stat label={messages.staked} stat={stat} />


### PR DESCRIPTION
We only set status when we've fetched all users. We need to revisit this and clean it up.

Note: this is currently on prod.