### PR TITLE
Fix vote weight column in top addr table

### DIFF
--- a/src/components/TopAddressesTable/TopAddressesTable.tsx
+++ b/src/components/TopAddressesTable/TopAddressesTable.tsx
@@ -56,7 +56,7 @@ const TopAddressesTable: React.FC<TopAddressesTableProps> = ({
     [pushRoute]
   )
 
-  const { status, users } = useUsers({ limit })
+  const { status, users } = useUsers()
   let columns = [{ title: 'Rank', className: styles.rankColumn }]
   if (!isMobile) {
     columns = columns.concat([
@@ -70,7 +70,7 @@ const TopAddressesTable: React.FC<TopAddressesTableProps> = ({
     return total.add(activeStake)
   }, new BN('0'))
 
-  const data: TableUser[] = users
+  let data: TableUser[] = users
     .map(user => {
       const activeStake = getActiveStake(user)
       const voteWeight = Audius.getBNPercentage(
@@ -91,6 +91,10 @@ const TopAddressesTable: React.FC<TopAddressesTableProps> = ({
       rank: index + 1,
       ...user
     }))
+
+  if (limit) {
+    data = data.slice(0, limit)
+  }
 
   const renderRow = (data: TableUser) => {
     return (


### PR DESCRIPTION
Fixes the `vote weight` column in the Top Addresses by Voting Weight table. 
If there is a limit, the `totalVotingPowerStake` the user's stake was divided by to get the percentage was incorrect. 

Closes AUD-125