### PR TITLE
Fix dashboard scroll lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,9 +41,9 @@
       }
     },
     "@audius/stems": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@audius/stems/-/stems-0.3.3.tgz",
-      "integrity": "sha512-brm6za5f+zcNCyFWVXMR3j6l45cuMefPqMLK4rwbKlm7R9Tze+Cq3/MSLnWoGx2wP0+WBMYzr00QQL5MPWk+ZQ==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@audius/stems/-/stems-0.3.4.tgz",
+      "integrity": "sha512-gZm2ebG93T0yM2P+WdazwYBW5rQdyAXzwU49pue5eeqkSKMQ8ei945Q4PaPfeeI66GauruWAtqREleB4dUSZvA==",
       "requires": {
         "classnames": "^2.2.6",
         "lodash": "^4.17.20",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@audius/libs": "1.1.5",
-    "@audius/stems": "^0.3.3",
+    "@audius/stems": "0.3.4",
     "@reduxjs/toolkit": "^1.4.0",
     "chart.js": "^2.9.3",
     "clsx": "^1.1.1",

--- a/src/components/DelegatesModal/DelegatesModal.tsx
+++ b/src/components/DelegatesModal/DelegatesModal.tsx
@@ -69,8 +69,11 @@ const DelegatesModal: React.FC<DelegatesModalProps> = ({
 
   const pushRoute = usePushRoute()
   const onRowClick = useCallback(
-    (row: Delegator) => pushRoute(accountPage(row.address)),
-    [pushRoute]
+    (row: Delegator) => {
+      onClose()
+      pushRoute(accountPage(row.address))
+    },
+    [onClose, pushRoute]
   )
 
   if (data.length === 0) {

--- a/src/components/DelegatorsModal/DelegatorsModal.tsx
+++ b/src/components/DelegatorsModal/DelegatorsModal.tsx
@@ -117,9 +117,10 @@ const DelegatorsTable: React.FC<DelegatorsTableProps> = ({
   const pushRoute = usePushRoute()
   const onRowClick = useCallback(
     (row: Delegator) => {
+      onClose()
       pushRoute(accountPage(row.address))
     },
-    [pushRoute]
+    [onClose, pushRoute]
   )
 
   const renderTableRow = (data: Delegator) => {


### PR DESCRIPTION
When closing a modal by pushing a new route which un-mounts it, the scroll lock `overflow:hidden` is left on the body of the html, preventing the user from scrolling. There was an issue in the stems modal component which is fixed in this version patch. 
The modal is also left open if close is not called and you navigate back to the page.  

Closes AUD-132