### PR TITLE
Don't use cached user from graphql

### DIFF
--- a/src/store/cache/user/graph/hooks.ts
+++ b/src/store/cache/user/graph/hooks.ts
@@ -67,7 +67,8 @@ export const useUsers = (status: Status | undefined) => {
 
 export const useUser = (
   wallet: string,
-  setStatus: (status: Status) => void
+  setStatus: (status: Status) => void,
+  hasUser: boolean
 ) => {
   const [didFetch, setDidFetch] = useState(false)
   const { error: gqlError, data: gqlData } = useQuery<UserData, UserVars>(
@@ -80,14 +81,13 @@ export const useUser = (
   useEffect(() => {
     setDidFetch(false)
   }, [wallet, setDidFetch])
-
   const dispatch = useDispatch()
   useEffect(() => {
-    if (!didFetch && gqlData) {
+    if (!didFetch && !hasUser && gqlData) {
       setDidFetch(true)
       dispatch(populateUsers([gqlData.user], setStatus))
     }
-  }, [gqlData, dispatch, setStatus, didFetch, setDidFetch])
+  }, [hasUser, gqlData, dispatch, setStatus, didFetch, setDidFetch])
 
   return {
     error: gqlError

--- a/src/store/cache/user/hooks.ts
+++ b/src/store/cache/user/hooks.ts
@@ -313,7 +313,7 @@ export const useUser = ({ wallet }: UseUserProps): UseUserResponse => {
     if (status !== Status.Loading && !user) setStatus(Status.Loading)
   }, [wallet, user, status])
 
-  const { error } = useGraphUser(wallet, setStatus)
+  const { error } = useGraphUser(wallet, setStatus, !!user)
 
   const dispatch = useDispatch()
   useEffect(() => {


### PR DESCRIPTION
What happens if you perform a tx action to update your stake/delegation is that the code to perform that action waits for metamask tx confirmation and manually updates the user in the cache, but the use of the graph in `useUser` fetches the user every time from the graph and sets it in the store. Because it doesn't have the updated values, old values were shown. 
The solution is to not fetch from the graph if the user is already in the store.

Closes AUD-174