### PR TITLE
Add CI for updating the protocol dashboard on IPFS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ jobs:
           command: |
             DNS_NAME=_dnslink.dashboard.staging.audius.org
             CID=$(cat ./build_cid.txt)
-            echo '{"Comment": "Update the ipfs CID for the protocol dashboard","Changes": [ {"Action": "UPSERT","ResourceRecordSet": {"Name": ""'"$DNS_NAME"'"","Type": "TXT","TTL": 600,"ResourceRecords": [ {"Value": "\"dnslink=/ipfs/"'"$CID"'"\"" } ] } } ]}' | tee change-record.json
+            echo '{"Comment": "Update the ipfs CID for the protocol dashboard","Changes": [ {"Action": "UPSERT","ResourceRecordSet": {"Name": "'"$DNS_NAME"'","Type": "TXT","TTL": 600,"ResourceRecords": [ {"Value": "\"dnslink=/ipfs/'"$CID"'\"" } ] } } ]}' | tee change-record.json
             aws route53 change-resource-record-sets --hosted-zone-id Z1MUWPKHC6C6L4 --change-batch file://$(pwd)/change-record.json
 
   build-prod:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,10 +51,14 @@ jobs:
       - run:
           name: build
           command: npm run build:stage
+      - run:
+          name: zip build
+          command: zip -r build.zip ./build
       - persist_to_workspace:
           root: ./
           paths:
             - build
+            - build.zip
 
   deploy-staging:
     working_directory: ~/protocol-dashboard
@@ -68,7 +72,36 @@ jobs:
           at: ./
       - run:
           name: Deploy to S3
-          command: aws s3 sync build s3://dashboard.staging.audius.org --delete --cache-control max-age=0
+          command: |
+            aws s3 sync build s3://dashboard.staging.audius.org --delete --cache-control max-age=0
+            aws s3 cp build.zip s3://dashboard.staging.audius.org/build.zip --cache-control max-age=0
+
+  update-staging-ga-build:
+    working_directory: ~/protocol-dashboard
+    docker:
+      - image: circleci/node:10.13
+    steps:
+      - attach_workspace:
+          at: ./
+      - run:
+          name: build
+          command: npm run update-build:stage
+
+  update-staging-records:
+    working_directory: ~/protocol-dashboard
+    docker:
+      - image: circleci/python:2.7-jessie
+    steps:
+      - run:
+          name: install-awscli
+          command: sudo pip install awscli
+      - run:
+          name: Update AWS records
+          command: |
+            DNS_NAME=_dnslink.dashboard.staging.audius.org
+            CID=$(cat ./build_cid.txt)
+            echo "{\n"Comment": "Update the ipfs CID for the protocol dashboard",\n"Changes": [\n {\n"Action": "UPSERT",\n"ResourceRecordSet": {\n"Name": "$DNS_NAME",\n"Type": "TXT",\n"TTL": 600,\n"ResourceRecords": [\n {\n"Value": "\"dnslink=/ipfs/$CID\""\n }\n ]\n }\n }\n ]}" | tee change-record.json
+            # aws route53 change-resource-record-sets --hosted-zone-id Z1MUWPKHC6C6L4 --change-batch ./change-record.json
 
   build-prod:
     working_directory: ~/protocol-dashboard
@@ -81,6 +114,9 @@ jobs:
       - run:
           name: build
           command: npm run build:prod
+      - run:
+          name: zip build
+          command: zip -r build.zip ./build
       - persist_to_workspace:
           root: ./
           paths:
@@ -101,6 +137,7 @@ jobs:
           command: |
             aws s3 sync build s3://dashboard.audius.org --delete --cache-control max-age=604800
             aws s3 cp s3://dashboard.audius.org/index.html s3://dashboard.audius.org/index.html --cache-control max-age=0,no-cache,no-store,must-revalidate --content-type text/html --metadata-directive REPLACE --acl public-read
+            aws s3 cp build.zip s3://dashboard.audius.org/build.zip --cache-control max-age=0
 
 workflows:
   version: 2
@@ -114,9 +151,22 @@ workflows:
           context: Audius Client
           requires:
             - build-staging
-          filters:
-            branches:
-              only: /^main$/
+          # filters:
+          #   branches:
+          #     only: /^main$/
+      - update-staging-ga-build:
+          requires:
+            - deploy-staging
+          # filters:
+          #   branches:
+          #     only: /^main$/
+      - update-staging-records:
+          type: approval
+          requires:
+            - update-staging-ga-build
+          # filters:
+          #   branches:
+          #     only: /^main$/
       - build-prod:
           requires:
             - init

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,7 +125,7 @@ jobs:
       - persist_to_workspace:
           root: ./
           paths:
-            - build
+            - ./*
 
   deploy-prod:
     working_directory: ~/protocol-dashboard
@@ -144,6 +144,39 @@ jobs:
             aws s3 cp s3://dashboard.audius.org/index.html s3://dashboard.audius.org/index.html --cache-control max-age=0,no-cache,no-store,must-revalidate --content-type text/html --metadata-directive REPLACE --acl public-read
             aws s3 cp build.zip s3://dashboard.audius.org/build.zip --cache-control max-age=0
 
+  update-prod-ga-build:
+    working_directory: ~/protocol-dashboard
+    docker:
+      - image: circleci/node:10.13
+    steps:
+      - attach_workspace:
+          at: ./
+      - run:
+          name: update build in ga
+          command: npm run update-build:prod
+      - persist_to_workspace:
+          root: ./
+          paths:
+            - ./build_cid.txt
+
+  update-prod-records:
+    working_directory: ~/protocol-dashboard
+    docker:
+      - image: circleci/python:2.7-jessie
+    steps:
+      - run:
+          name: install-awscli
+          command: sudo pip install awscli
+      - attach_workspace:
+          at: ./
+      - run:
+          name: Update AWS records
+          command: |
+            DNS_NAME=_dnslink.dashboard.audius.org
+            CID=$(cat ./build_cid.txt)
+            echo '{"Comment": "Update the ipfs CID for the protocol dashboard","Changes": [ {"Action": "UPSERT","ResourceRecordSet": {"Name": "'"$DNS_NAME"'","Type": "TXT","TTL": 600,"ResourceRecords": [ {"Value": "\"dnslink=/ipfs/'"$CID"'\"" } ] } } ]}' | tee change-record.json
+            aws route53 change-resource-record-sets --hosted-zone-id Z1MUWPKHC6C6L4 --change-batch file://$(pwd)/change-record.json
+
 workflows:
   version: 2
   build-deploy:
@@ -156,29 +189,29 @@ workflows:
           context: Audius Client
           requires:
             - build-staging
-          # filters:
-          #   branches:
-          #     only: /^main$/
+          filters:
+            branches:
+              only: /^main$/
       - update-staging-ga-build:
           requires:
             - deploy-staging
-          # filters:
-          #   branches:
-          #     only: /^main$/
+          filters:
+            branches:
+              only: /^main$/
       - hold-update-staging-records:
           type: approval
           requires:
             - update-staging-ga-build
-          # filters:
-          #   branches:
-          #     only: /^main$/
+          filters:
+            branches:
+              only: /^main$/
       - update-staging-records:
           context: Audius Client
           requires:
             - hold-update-staging-records
-          # filters:
-          #   branches:
-          #     only: /^main$/
+          filters:
+            branches:
+              only: /^main$/
       - build-prod:
           requires:
             - init
@@ -193,6 +226,26 @@ workflows:
           context: Audius Client
           requires:
             - hold-deploy-prod
+          filters:
+            branches:
+              only: /^main$/
+      - update-prod-ga-build:
+          requires:
+            - deploy-prod
+          filters:
+            branches:
+              only: /^main$/
+      - hold-update-prod-records:
+          type: approval
+          requires:
+            - update-prod-ga-build
+          filters:
+            branches:
+              only: /^main$/
+      - update-prod-records:
+          context: Audius Client
+          requires:
+            - hold-update-prod-records
           filters:
             branches:
               only: /^main$/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,6 +85,10 @@ jobs:
       - run:
           name: update build in ga
           command: npm run update-build:stage
+      - persist_to_workspace:
+          root: ./
+          paths:
+            - ./build_cid.txt
 
   update-staging-records:
     working_directory: ~/protocol-dashboard

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ jobs:
           command: |
             DNS_NAME=_dnslink.dashboard.staging.audius.org
             CID=$(cat ./build_cid.txt)
-            echo '{"Comment": "Update the ipfs CID for the protocol dashboard","Changes": [ {"Action": "UPSERT","ResourceRecordSet": {"Name": "$DNS_NAME","Type": "TXT","TTL": 600,"ResourceRecords": [ {"Value": "\"dnslink=/ipfs/$CID\"" } ] } } ]}' | tee change-record.json
+            echo '{"Comment": "Update the ipfs CID for the protocol dashboard","Changes": [ {"Action": "UPSERT","ResourceRecordSet": {"Name": ""'"$DNS_NAME"'"","Type": "TXT","TTL": 600,"ResourceRecords": [ {"Value": "\"dnslink=/ipfs/"'"$CID"'"\"" } ] } } ]}' | tee change-record.json
             aws route53 change-resource-record-sets --hosted-zone-id Z1MUWPKHC6C6L4 --change-batch file://$(pwd)/change-record.json
 
   build-prod:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,6 +173,7 @@ workflows:
           #   branches:
           #     only: /^main$/
       - update-staging-records:
+          context: Audius Client
           requires:
             - hold-update-staging-records
           # filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,10 +159,16 @@ workflows:
           # filters:
           #   branches:
           #     only: /^main$/
-      - update-staging-records:
+      - hold-update-staging-records:
           type: approval
           requires:
             - update-staging-ga-build
+          # filters:
+          #   branches:
+          #     only: /^main$/
+      - update-staging-records:
+          requires:
+            - hold-update-staging-records
           # filters:
           #   branches:
           #     only: /^main$/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,13 +94,15 @@ jobs:
       - run:
           name: install-awscli
           command: sudo pip install awscli
+      - attach_workspace:
+          at: ./
       - run:
           name: Update AWS records
           command: |
             DNS_NAME=_dnslink.dashboard.staging.audius.org
             CID=$(cat ./build_cid.txt)
-            echo "{\n"Comment": "Update the ipfs CID for the protocol dashboard",\n"Changes": [\n {\n"Action": "UPSERT",\n"ResourceRecordSet": {\n"Name": "$DNS_NAME",\n"Type": "TXT",\n"TTL": 600,\n"ResourceRecords": [\n {\n"Value": "\"dnslink=/ipfs/$CID\""\n }\n ]\n }\n }\n ]}" | tee change-record.json
-            # aws route53 change-resource-record-sets --hosted-zone-id Z1MUWPKHC6C6L4 --change-batch ./change-record.json
+            echo '{"Comment": "Update the ipfs CID for the protocol dashboard","Changes": [ {"Action": "UPSERT","ResourceRecordSet": {"Name": "$DNS_NAME","Type": "TXT","TTL": 600,"ResourceRecords": [ {"Value": "\"dnslink=/ipfs/$CID\"" } ] } } ]}' | tee change-record.json
+            aws route53 change-resource-record-sets --hosted-zone-id Z1MUWPKHC6C6L4 --change-batch file://$(pwd)/change-record.json
 
   build-prod:
     working_directory: ~/protocol-dashboard

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,8 +57,7 @@ jobs:
       - persist_to_workspace:
           root: ./
           paths:
-            - build
-            - build.zip
+            - ./*
 
   deploy-staging:
     working_directory: ~/protocol-dashboard
@@ -84,7 +83,7 @@ jobs:
       - attach_workspace:
           at: ./
       - run:
-          name: build
+          name: update build in ga
           command: npm run update-build:stage
 
   update-staging-records:

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,11 +44,6 @@
         "tweetnacl-util": "^0.15.0"
       },
       "dependencies": {
-        "node-fetch": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
-        },
         "p-timeout": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
@@ -14374,11 +14369,6 @@
             "multihashes": "^1.0.1",
             "murmurhash3js-revisited": "^3.0.0"
           }
-        },
-        "node-fetch": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
         }
       }
     },
@@ -14986,11 +14976,6 @@
             "graceful-fs": "^4.1.6",
             "universalify": "^2.0.0"
           }
-        },
-        "node-fetch": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
         },
         "universalify": {
           "version": "2.0.0",
@@ -16325,6 +16310,17 @@
       "requires": {
         "node-fetch": "^1.0.1",
         "whatwg-fetch": ">=0.10.0"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+          "requires": {
+            "encoding": "^0.1.11",
+            "is-stream": "^1.0.1"
+          }
+        }
       }
     },
     "isstream": {
@@ -18500,11 +18496,6 @@
               }
             }
           }
-        },
-        "node-fetch": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
         },
         "node-forge": {
           "version": "0.9.2",
@@ -20796,13 +20787,6 @@
         "@babel/runtime": "^7.1.2",
         "did-resolver": "^1.1.0",
         "node-fetch": "^2.6.0"
-      },
-      "dependencies": {
-        "node-fetch": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
-        }
       }
     },
     "murmurhash3js": {
@@ -20932,13 +20916,9 @@
       "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
     },
     "node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
-      }
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "node-forge": {
       "version": "0.10.0",
@@ -24216,11 +24196,6 @@
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "node-fetch": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
     "start:stage": "env-cmd -f .env.stage npm start",
     "start:prod": "env-cmd -f .env.prod npm start",
     "build": "react-scripts build",
-    "build:stage": "env-cmd -f .env.stage npm run build",
-    "build:prod": "env-cmd -f .env.prod npm run build",
+    "build:stage": "env-cmd -f .env.stage npm run build && node ./scripts/rerouteLegacy.js stage",
+    "build:prod": "env-cmd -f .env.prod npm run build && node ./scripts/rerouteLegacy.js",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "lint": "npm run prettier:check",
@@ -54,7 +54,10 @@
     "prettier:check": "npm run prettier:base -- --list-different \"src/**/*.{ts,tsx}\"",
     "prettier:write": "npm run prettier:base -- --write \"src/**/*.{ts,tsx}\"",
     "pull-dev-accounts": "node ./scripts/pullDevAccounts.js",
-    "advance-blocks": "node ./scripts/advanceBlocks.js"
+    "advance-blocks": "node ./scripts/advanceBlocks.js",
+    "update-build:dev": "node ./scripts/updateBuild.js dev",
+    "update-build:stage": "node ./scripts/updateBuild.js stage",
+    "update-build:prod": "node ./scripts/updateBuild.js prod"
   },
   "eslintConfig": {
     "extends": "react-app"
@@ -91,6 +94,7 @@
     "@types/semver": "^6.2.1",
     "@types/url-join": "^4.0.0",
     "env-cmd": "^9.0.3",
+    "node-fetch": "^2.6.1",
     "prettier": "^1.19.1",
     "redux-devtools-extension": "^2.13.8",
     "typescript": "^4.0.2"

--- a/scripts/rerouteLegacy.js
+++ b/scripts/rerouteLegacy.js
@@ -1,0 +1,53 @@
+const fs = require('fs')
+const path = require('path');
+
+let getContent = (baseUrl, path) => `
+<head>
+  <meta http-equiv="refresh" content="0;URL=${baseUrl}/#/${path}" />
+</head>
+<body>
+  <p>This page has ben moved to <a href="${baseUrl}/#/${path}">${baseUrl}/#/${path}</a></p>
+</body>`
+
+const BUILD_PATH = './build'
+
+const redirectPaths = [
+  'analytics',
+  'governance',
+  'services',
+  'services/discovery-node',
+  'services/content-node',
+  'services/service-providers',
+  'services/users',
+] 
+
+const getBaseUrl = () => {
+  if (process.argv.length === 3 && process.argv[2] == 'stage') {
+    return 'https://dashboard.staging.audius.org'
+  }
+  return 'https://dashboard.audius.org'
+}
+
+const writeLegacyPathRedirects = () => {
+  if (!fs.existsSync(BUILD_PATH)) {
+    // If the build doesn't exist, return
+    console.error(`Build path: ${BUILD_PATH} does not exist`)
+    return 
+  }
+  for (let pathName of redirectPaths) {
+    const fileFolder = path.join(__dirname, '../', BUILD_PATH, pathName)
+    fs.mkdirSync(fileFolder, { recursive: true })
+
+    const filePath = path.join(fileFolder, 'index.html')
+    console.log(filePath)
+
+    const baseURL = getBaseUrl()
+    const file = getContent(baseURL, pathName)
+    fs.writeFileSync(filePath, file, 'utf8')
+  }
+}
+
+
+if (typeof require !== 'undefined' && require.main === module) {
+  writeLegacyPathRedirects();
+}

--- a/scripts/updateBuild.js
+++ b/scripts/updateBuild.js
@@ -38,16 +38,17 @@ const updateContentNodePeers = async () => {
     console.error('unable to update content node ipfs peers')
     process.exit(1)
   }
+  console.log('Added ipfs peers')
 }
 
 const updateGABuild = async () => {
   const res = await fetch(`${endpoint}/protocol_dashboard/update_build`)
   const response = await res.json()
-  console.log({ response})
   if (!response.success) {
     console.error('unable to update GA build')
     process.exit(1)
   }
+  console.log('Updated build folder in GA')
 }
 
 const pinGABuild = async () => {
@@ -57,7 +58,9 @@ const pinGABuild = async () => {
     process.exit(1)
   }
   const response = await res.json()
-  return response.cid
+  const cid = response.cid
+  console.log(`IPFS Pin Added CID: ${cid}`)
+  return cid
 }
 
 const run = async () => {

--- a/scripts/updateBuild.js
+++ b/scripts/updateBuild.js
@@ -33,7 +33,7 @@ const endpoint = config[env].gaEndpoint
 const updateContentNodePeers = async () => {
   const res = await fetch(`${endpoint}/protocol_dashboard/peer_content_nodes`)
   const response = await res.json()
-  console.log({ response})
+  console.log({ response })
   if (!response.success) {
     console.error('unable to update content node ipfs peers')
     process.exit(1)

--- a/scripts/updateBuild.js
+++ b/scripts/updateBuild.js
@@ -1,0 +1,76 @@
+const fs = require('fs')
+const fetch = require('node-fetch')
+
+const args = process.argv
+console.log(process.argv)
+if (args.length < 3) {
+  console.error('Need to provide environment <dev|stage|prod>')
+  process.exit(1)
+} else if (args.length > 3) {
+  console.warn('Extra arg provided')
+}
+
+const env = args[2]
+if (env !== 'dev' && env !== 'stage' && env !== 'prod') {
+  console.error('Environment must be <dev|stage|prod>')
+  process.exit(1)
+}
+
+const config = {
+  dev: {
+    gaEndpoint: 'http://localhost:9001'
+  },
+  stage: {
+    gaEndpoint: 'https://staging.audius.co'
+  },
+  prod: {
+    gaEndpoint: 'https://audius.co'
+  }
+}
+
+const endpoint = config[env].gaEndpoint
+
+const updateContentNodePeers = async () => {
+  const res = await fetch(`${endpoint}/protocol_dashboard/peer_content_nodes`)
+  const response = await res.json()
+  console.log({ response})
+  if (!response.success) {
+    console.error('unable to update content node ipfs peers')
+    process.exit(1)
+  }
+}
+
+const updateGABuild = async () => {
+  const res = await fetch(`${endpoint}/protocol_dashboard/update_build`)
+  const response = await res.json()
+  console.log({ response})
+  if (!response.success) {
+    console.error('unable to update GA build')
+    process.exit(1)
+  }
+}
+
+const pinGABuild = async () => {
+  const res = await fetch(`${endpoint}/protocol_dashboard/pin_build`)
+  if (!res.ok) {
+    console.error('unable to pin GA build')
+    process.exit(1)
+  }
+  const response = await res.json()
+  return response.cid
+}
+
+const run = async () => {
+  try {
+    await updateContentNodePeers()
+    await updateGABuild()
+    const cid = await pinGABuild()
+    fs.writeFileSync(`./build_cid.txt`, cid)
+    process.exit()
+  } catch (err) {
+    console.log(err)
+    process.exit(1)
+  }
+}
+
+run()

--- a/scripts/updateBuild.js
+++ b/scripts/updateBuild.js
@@ -21,10 +21,10 @@ const config = {
     gaEndpoint: 'http://localhost:9001'
   },
   stage: {
-    gaEndpoint: 'https://staging.audius.co'
+    gaEndpoint: 'https://general-admission.staging.audius.co'
   },
   prod: {
-    gaEndpoint: 'https://audius.co'
+    gaEndpoint: 'https://general-admission.audius.co'
   }
 }
 


### PR DESCRIPTION
## Summary
* Adds a script to query GA to update the build folder and pin files to IPFS
* Adds a script to generate redirect pages for when the dapp is hosted on ipfs
* Updates CI
  * Creates a build.zip folder
  * Runs script to notify GA to update and pin build in ipfs
  * Updates record w/ new CID given from GA

NOTE: I tested this on the stage build end to end, not but on prod
NOTE: I modified the aws permissions for the circleci user to have route53 access