### PR TITLE
Add quorum to proposal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -226,9 +226,9 @@
       }
     },
     "@audius/libs": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/@audius/libs/-/libs-1.1.13.tgz",
-      "integrity": "sha512-QQOIrDyYS/d9PB2qnSCcaEopNrf1mrrGngM+26kX/7iMftiIVhSpmndMCyhpcx4zJ7PGE7UcMj+lbFwMQkPq4Q==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/@audius/libs/-/libs-1.1.14.tgz",
+      "integrity": "sha512-+gfgFJIO+D6FHOUeCNYn5iofqwVHc8BYZwBr+QMt44CQ/yLMoSt3Q1NTiu4IW+1JKQAYsUSFR8djWY84q9abyg==",
       "requires": {
         "@audius/hedgehog": "^1.0.8",
         "@ethersproject/solidity": "^5.0.5",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "3box": "^1.22.2",
     "@apollo/client": "^3.3.7",
-    "@audius/libs": "1.1.13",
+    "@audius/libs": "^1.1.14",
     "@audius/stems": "0.3.4",
     "@reduxjs/toolkit": "^1.4.0",
     "chart.js": "^2.9.3",

--- a/src/components/ProposalHero/ProposalHero.module.css
+++ b/src/components/ProposalHero/ProposalHero.module.css
@@ -127,3 +127,54 @@
   justify-content: center;
   min-height: 400px;
 }
+
+.quorumContainer {
+  margin-top: 8px;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  text-transform: uppercase;
+  font-weight: var(--font-bold);
+  font-size: var(--font-xs);
+  line-height: 15px;
+  text-align: center;
+  letter-spacing: 1px;
+}
+
+.quorumValue {
+  margin: 0px 8px;
+}
+
+
+.quorumStatusContainer {
+  font-weight: var(--font-demi-bold);
+  font-size: var(--font-l);
+  line-height: 22px;
+  color: var(--neutral);
+  text-transform: capitalize;
+  display: inline-flex;
+  margin-top: 16px;
+  align-items: center;
+}
+
+.circle {
+  height: 24px;
+  width: 24px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-right: 8px;
+}
+
+.circle.met {
+  background-color: #6BCF63;
+}
+
+.circle.notMet {
+  background-color: var(--neutral-light-4);
+}
+
+.icon path {
+  fill: var(--static-white);
+}

--- a/src/components/ProposalHero/ProposalHero.tsx
+++ b/src/components/ProposalHero/ProposalHero.tsx
@@ -26,11 +26,13 @@ import {
 import { useAccountUser } from 'store/account/hooks'
 import Tooltip, { Position } from 'components/Tooltip'
 import { createStyles } from 'utils/mobile'
+import { IconCheck, IconRemove } from '@audius/stems'
 
 import desktopStyles from './ProposalHero.module.css'
 import mobileStyles from './ProposalHeroMobile.module.css'
 import Loading from 'components/Loading'
 import getActiveStake from 'utils/activeStake'
+import clsx from 'clsx'
 
 const styles = createStyles({ desktopStyles, mobileStyles })
 
@@ -39,7 +41,11 @@ const messages = {
   voteAgainst: 'Vote Against',
   timeRemaining: 'Est. Time Remaining',
   targetBlock: 'Target Block',
-  notVoted: 'NOT-VOTED'
+  notVoted: 'NOT-VOTED',
+  voted: 'VOTED',
+  quorum: 'QUORUM',
+  quorumMet: 'Quorum Met',
+  quorumNotMet: 'Quorum Not Met'
 }
 
 type VoteCTAProps = {
@@ -183,6 +189,13 @@ const ProposalHero: React.FC<ProposalHeroProps> = ({
     </StandaloneBox>
   )
 
+  const totalMagnitudeVoted = proposal
+    ? proposal?.voteMagnitudeYes.add(proposal?.voteMagnitudeNo)
+    : Utils.toBN('0')
+  const hasMetQuorum = proposal
+    ? totalMagnitudeVoted.gte(proposal.quorum)
+    : false
+
   return (
     <Paper className={styles.container}>
       {proposal && proposal.proposer ? (
@@ -210,6 +223,22 @@ const ProposalHero: React.FC<ProposalHeroProps> = ({
                   </div>
                 )}
               </div>
+              {isActive && hasMetQuorum && (
+                <div className={styles.quorumStatusContainer}>
+                  <div className={clsx(styles.circle, styles.met)}>
+                    <IconCheck className={styles.icon} />
+                  </div>
+                  {messages.quorumMet}
+                </div>
+              )}
+              {isActive && !hasMetQuorum && (
+                <div className={styles.quorumStatusContainer}>
+                  <div className={clsx(styles.circle, styles.notMet)}>
+                    <IconRemove className={styles.icon} />
+                  </div>
+                  {messages.quorumNotMet}
+                </div>
+              )}
             </div>
             <div className={styles.stats}>
               <VoteMeter
@@ -223,6 +252,25 @@ const ProposalHero: React.FC<ProposalHeroProps> = ({
               >
                 {`${formatShortAud(amountAbstained)} ${messages.notVoted}`}
               </Tooltip>
+              {isActive && (
+                <div className={styles.quorumContainer}>
+                  <Tooltip
+                    text={formatWei(totalMagnitudeVoted)}
+                    position={Position.BOTTOM}
+                    className={styles.quorumValue}
+                  >
+                    {`${formatShortAud(totalMagnitudeVoted)} ${messages.voted}`}
+                  </Tooltip>
+                  {' / '}
+                  <Tooltip
+                    text={formatWei(proposal.quorum)}
+                    position={Position.BOTTOM}
+                    className={styles.quorumValue}
+                  >
+                    {`${formatShortAud(proposal.quorum)} ${messages.quorum}`}
+                  </Tooltip>
+                </div>
+              )}
             </div>
           </div>
         </>

--- a/src/services/Audius/governance/governance.ts
+++ b/src/services/Audius/governance/governance.ts
@@ -222,6 +222,14 @@ export default class Governance {
     }))
   }
 
+  async getProposalQuorum(proposalId: number): Promise<BN> {
+    await this.aud.hasPermissions()
+    const quorumAmount: BN = await this.getContract().calculateQuorum(
+      proposalId
+    )
+    return quorumAmount
+  }
+
   /* -------------------- Governance Write -------------------- */
 
   async submitProposal(args: {

--- a/src/store/cache/proposals/hooks.ts
+++ b/src/store/cache/proposals/hooks.ts
@@ -60,12 +60,14 @@ export function fetchActiveProposals(): ThunkAction<
       await Promise.all(
         proposalIds.map(async id => {
           const proposal = await aud.Governance.getProposalById(id)
+          const quorum = await aud.Governance.getProposalQuorum(id)
           const {
             name,
             description
           } = await aud.Governance.getProposalSubmissionById(id)
           proposal.name = name
           proposal.description = description
+          proposal.quorum = quorum
           return proposal
         })
       )
@@ -87,8 +89,10 @@ export function fetchAllProposals(): ThunkAction<
       proposalEvents.map(async (p: ProposalEvent) => {
         const { proposalId, description, name } = p
         const proposal = await aud.Governance.getProposalById(proposalId)
+        const quorum = await aud.Governance.getProposalQuorum(proposalId)
         proposal.description = description
         proposal.name = name
+        proposal.quorum = quorum
         if (proposal.outcome !== Outcome.InProgress) {
           const evaluationBlockNumber = await aud.Governance.getProposalEvaluationBlock(
             proposalId
@@ -108,12 +112,14 @@ export function fetchProposal(
 ): ThunkAction<void, AppState, Audius, Action<string>> {
   return async (dispatch, getState, aud) => {
     const proposal = await aud.Governance.getProposalById(proposalId)
+    const quorum = await aud.Governance.getProposalQuorum(proposalId)
     const {
       name,
       description
     } = await aud.Governance.getProposalSubmissionById(proposalId)
     proposal.name = name
     proposal.description = description
+    proposal.quorum = quorum
     if (proposal.outcome !== Outcome.InProgress) {
       const evaluationBlockNumber = await aud.Governance.getProposalEvaluationBlock(
         proposalId

--- a/src/types.ts
+++ b/src/types.ts
@@ -151,6 +151,7 @@ export type Proposal = {
   name?: string
   description?: string
   evaluatedBlock?: Block
+  quorum: BigNumber
 }
 
 export type ProposalEvent = {


### PR DESCRIPTION
## Summary
* Update libs to get quorum function from gov. 
* Add binding to audius service
* Update Proposal type to have quorum amount
* Display in Proposal UI

Note: the added quorum met/not met and voted/quorum ui are only displayed if the proposal is active
![Screen Shot 2021-02-25 at 11 54 39 AM](https://user-images.githubusercontent.com/7064122/109188450-f53e5200-7760-11eb-9bc5-14683c6a1fef.png)
![Screen Shot 2021-02-25 at 11 58 03 AM](https://user-images.githubusercontent.com/7064122/109188448-f53e5200-7760-11eb-825f-3d1e3a2e1acc.png)
