### PR TITLE
Add execute governance proposal button and fix voting states

### DIFF
--- a/src/components/Proposal/Proposal.tsx
+++ b/src/components/Proposal/Proposal.tsx
@@ -1,13 +1,13 @@
 import React, { useCallback } from 'react'
 import clsx from 'clsx'
 
-import { Proposal as ProposalType, Vote } from 'types'
+import { Outcome, Proposal as ProposalType, Vote } from 'types'
 import VoteMeter from 'components/VoteMeter'
 import ProposalStatusBadge from 'components/ProposalStatusBadge'
 import { usePushRoute } from 'utils/effects'
 import { proposalPage } from 'utils/routes'
 import { leftPadZero, getHumanReadableTime, getDate } from 'utils/format'
-import { useProposalTimeRemaining } from 'store/cache/proposals/hooks'
+import { useExecutionDelayTimeRemaining, useGetInProgressProposalSubstate, useProposalMilestoneBlocks, useProposalTimeRemaining } from 'store/cache/proposals/hooks'
 import ProposalStatusChip from 'components/ProposalStatusChip'
 import Voted from 'components/Voted'
 import { createStyles } from 'utils/mobile'
@@ -33,6 +33,44 @@ type OwnProps = {
 
 type ProposalProps = OwnProps
 
+const InProgressTimeRemaining: React.FC<{ proposal: ProposalType }> = ({
+  proposal
+}) => {
+  const { timeRemaining } = useProposalTimeRemaining(
+    proposal.submissionBlockNumber
+  )
+  return timeRemaining ?
+    <div
+      className={clsx(styles.timeRemaining, {
+        [styles.show]: timeRemaining
+      })}
+    >
+      {`${getHumanReadableTime(timeRemaining)} ${
+        messages.timeRemaining
+      }`}
+    </div>
+  : null
+}
+
+const ExecutionDelayTimeRemaining: React.FC<{votingDeadlineBlock: number }> = ({
+  votingDeadlineBlock
+}) => {
+  const { timeRemaining } = useExecutionDelayTimeRemaining(
+    votingDeadlineBlock
+  )
+  return timeRemaining ?
+    <div
+      className={clsx(styles.timeRemaining, {
+        [styles.show]: timeRemaining
+      })}
+    >
+      {`${getHumanReadableTime(timeRemaining)} ${
+        messages.timeRemaining
+      }`}
+    </div>
+  : null
+}
+
 const Proposal: React.FC<ProposalProps> = ({
   header,
   proposal,
@@ -46,9 +84,8 @@ const Proposal: React.FC<ProposalProps> = ({
     if (onClick) onClick()
     pushRoute(proposalPage(proposal.proposalId))
   }, [proposal, pushRoute, onClick])
-  const { timeRemaining } = useProposalTimeRemaining(
-    proposal.submissionBlockNumber
-  )
+  const inProgressProposalSubstate = useGetInProgressProposalSubstate(proposal)
+  const proposalMilestoneBlocks = useProposalMilestoneBlocks(proposal)
 
   const evaluatedBlockTimestamp = proposal?.evaluatedBlock?.timestamp ?? null
 
@@ -66,24 +103,27 @@ const Proposal: React.FC<ProposalProps> = ({
           {proposal.name || proposal.description || proposal.functionSignature}
         </div>
         <div className={clsx(styles.info, { [styles.infoHeader]: !!header })}>
-          <ProposalStatusBadge outcome={proposal.outcome} />
+          <ProposalStatusBadge outcome={inProgressProposalSubstate || proposal.outcome} />
           <div className={styles.id}>{leftPadZero(proposal.proposalId, 3)}</div>
-          {evaluatedBlockTimestamp ? (
+          { evaluatedBlockTimestamp ? (
             <div className={styles.executed}>
               {`Executed ${getDate(evaluatedBlockTimestamp * 1000)}`}
             </div>
-          ) : (
-            <div
-              className={clsx(styles.timeRemaining, {
-                [styles.show]: timeRemaining
-              })}
-            >
-              {timeRemaining &&
-                `${getHumanReadableTime(timeRemaining)} ${
-                  messages.timeRemaining
-                }`}
-            </div>
-          )}
+          ) :
+            <>
+              {
+                inProgressProposalSubstate === Outcome.InProgress &&
+                  <InProgressTimeRemaining proposal={proposal} />
+              }
+              {
+                inProgressProposalSubstate === Outcome.InProgressExecutionDelay &&
+                proposalMilestoneBlocks?.votingDeadlineBlock &&
+                  <ExecutionDelayTimeRemaining votingDeadlineBlock={
+                    proposalMilestoneBlocks.votingDeadlineBlock
+                  } />
+              }
+           </>
+          }
         </div>
       </div>
       <div className={styles.right}>

--- a/src/components/Proposal/Proposal.tsx
+++ b/src/components/Proposal/Proposal.tsx
@@ -7,7 +7,12 @@ import ProposalStatusBadge from 'components/ProposalStatusBadge'
 import { usePushRoute } from 'utils/effects'
 import { proposalPage } from 'utils/routes'
 import { leftPadZero, getHumanReadableTime, getDate } from 'utils/format'
-import { useExecutionDelayTimeRemaining, useGetInProgressProposalSubstate, useProposalMilestoneBlocks, useProposalTimeRemaining } from 'store/cache/proposals/hooks'
+import {
+  useExecutionDelayTimeRemaining,
+  useGetInProgressProposalSubstate,
+  useProposalMilestoneBlocks,
+  useProposalTimeRemaining
+} from 'store/cache/proposals/hooks'
 import ProposalStatusChip from 'components/ProposalStatusChip'
 import Voted from 'components/Voted'
 import { createStyles } from 'utils/mobile'
@@ -39,36 +44,30 @@ const InProgressTimeRemaining: React.FC<{ proposal: ProposalType }> = ({
   const { timeRemaining } = useProposalTimeRemaining(
     proposal.submissionBlockNumber
   )
-  return timeRemaining ?
+  return timeRemaining ? (
     <div
       className={clsx(styles.timeRemaining, {
         [styles.show]: timeRemaining
       })}
     >
-      {`${getHumanReadableTime(timeRemaining)} ${
-        messages.timeRemaining
-      }`}
+      {`${getHumanReadableTime(timeRemaining)} ${messages.timeRemaining}`}
     </div>
-  : null
+  ) : null
 }
 
-const ExecutionDelayTimeRemaining: React.FC<{votingDeadlineBlock: number }> = ({
-  votingDeadlineBlock
-}) => {
-  const { timeRemaining } = useExecutionDelayTimeRemaining(
-    votingDeadlineBlock
-  )
-  return timeRemaining ?
+const ExecutionDelayTimeRemaining: React.FC<{
+  votingDeadlineBlock: number
+}> = ({ votingDeadlineBlock }) => {
+  const { timeRemaining } = useExecutionDelayTimeRemaining(votingDeadlineBlock)
+  return timeRemaining ? (
     <div
       className={clsx(styles.timeRemaining, {
         [styles.show]: timeRemaining
       })}
     >
-      {`${getHumanReadableTime(timeRemaining)} ${
-        messages.timeRemaining
-      }`}
+      {`${getHumanReadableTime(timeRemaining)} ${messages.timeRemaining}`}
     </div>
-  : null
+  ) : null
 }
 
 const Proposal: React.FC<ProposalProps> = ({
@@ -103,27 +102,30 @@ const Proposal: React.FC<ProposalProps> = ({
           {proposal.name || proposal.description || proposal.functionSignature}
         </div>
         <div className={clsx(styles.info, { [styles.infoHeader]: !!header })}>
-          <ProposalStatusBadge outcome={inProgressProposalSubstate || proposal.outcome} />
+          <ProposalStatusBadge
+            outcome={inProgressProposalSubstate || proposal.outcome}
+          />
           <div className={styles.id}>{leftPadZero(proposal.proposalId, 3)}</div>
-          { evaluatedBlockTimestamp ? (
+          {evaluatedBlockTimestamp ? (
             <div className={styles.executed}>
               {`Executed ${getDate(evaluatedBlockTimestamp * 1000)}`}
             </div>
-          ) :
+          ) : (
             <>
-              {
-                inProgressProposalSubstate === Outcome.InProgress &&
-                  <InProgressTimeRemaining proposal={proposal} />
-              }
-              {
-                inProgressProposalSubstate === Outcome.InProgressExecutionDelay &&
-                proposalMilestoneBlocks?.votingDeadlineBlock &&
-                  <ExecutionDelayTimeRemaining votingDeadlineBlock={
-                    proposalMilestoneBlocks.votingDeadlineBlock
-                  } />
-              }
-           </>
-          }
+              {inProgressProposalSubstate === Outcome.InProgress && (
+                <InProgressTimeRemaining proposal={proposal} />
+              )}
+              {inProgressProposalSubstate ===
+                Outcome.InProgressExecutionDelay &&
+                proposalMilestoneBlocks?.votingDeadlineBlock && (
+                  <ExecutionDelayTimeRemaining
+                    votingDeadlineBlock={
+                      proposalMilestoneBlocks.votingDeadlineBlock
+                    }
+                  />
+                )}
+            </>
+          )}
         </div>
       </div>
       <div className={styles.right}>

--- a/src/components/ProposalHero/ProposalHero.module.css
+++ b/src/components/ProposalHero/ProposalHero.module.css
@@ -65,7 +65,7 @@
   border-bottom: 1px solid var(--neutral-light-8);
 }
 
-.timeRemaining {
+.voteStatusContainer {
   display: flex;
   flex-direction: column;
   align-items: flex-start;

--- a/src/components/ProposalHero/ProposalHero.module.css
+++ b/src/components/ProposalHero/ProposalHero.module.css
@@ -65,7 +65,7 @@
   border-bottom: 1px solid var(--neutral-light-8);
 }
 
-.voteStatusContainer {
+.timeRemaining {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
@@ -93,7 +93,7 @@
   align-items: flex-start;
 }
 
-.message {
+.time {
   font-weight: 800;
   font-size: var(--font-4xl);
   line-height: 44px;

--- a/src/components/ProposalHero/ProposalHero.module.css
+++ b/src/components/ProposalHero/ProposalHero.module.css
@@ -65,7 +65,7 @@
   border-bottom: 1px solid var(--neutral-light-8);
 }
 
-.timeRemaining {
+.voteStatusContainer {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
@@ -93,7 +93,7 @@
   align-items: flex-start;
 }
 
-.time {
+.message {
   font-weight: 800;
   font-size: var(--font-4xl);
   line-height: 44px;

--- a/src/components/ProposalHero/ProposalHero.tsx
+++ b/src/components/ProposalHero/ProposalHero.tsx
@@ -4,14 +4,7 @@ import { Utils } from '@audius/libs'
 import Paper from 'components/Paper'
 import VoteMeter from 'components/VoteMeter'
 import ProposalStatusBadge from 'components/ProposalStatusBadge'
-import {
-  Proposal,
-  Outcome,
-  Vote,
-  Address,
-  Status,
-  InProgressOutcomeSubstates
-} from 'types'
+import { Proposal, Outcome, Vote, Address, Status } from 'types'
 import Button, { ButtonType } from 'components/Button'
 import { leftPadZero, getDate, getHumanReadableTime } from 'utils/format'
 import { ReactComponent as IconThumbUp } from 'assets/img/iconThumbUp.svg'
@@ -59,7 +52,11 @@ type VoteCTAProps = {
   onExecuteProposal: () => void
   currentVote: Vote
   submissionBlock: number
-  inProgressProposalSubstate: null | InProgressOutcomeSubstates
+  inProgressProposalSubstate:
+    | null
+    | Outcome.InProgress
+    | Outcome.InProgressAwaitingExecution
+    | Outcome.InProgressExecutionDelay
 }
 
 const VoteCTA: React.FC<VoteCTAProps> = ({
@@ -96,8 +93,7 @@ const VoteCTA: React.FC<VoteCTAProps> = ({
         </div>
       </div>
       {isUserStaker &&
-        inProgressProposalSubstate ===
-          InProgressOutcomeSubstates.InProgressAwaitingExecution && (
+        inProgressProposalSubstate === Outcome.InProgressAwaitingExecution && (
           <div>
             <Button
               text="Evalute Proposal"
@@ -106,30 +102,28 @@ const VoteCTA: React.FC<VoteCTAProps> = ({
             />
           </div>
         )}
-      {isUserStaker &&
-        inProgressProposalSubstate ===
-          InProgressOutcomeSubstates.InProgress && (
-          <div className={styles.vote}>
-            <Button
-              leftIcon={<IconThumbUp />}
-              className={styles.voteFor}
-              text={messages.voteFor}
-              type={ButtonType.GREEN}
-              onClick={onVoteFor}
-              isDepressed={currentVote === Vote.Yes}
-              isDisabled={currentVote === Vote.Yes}
-            />
-            <Button
-              leftIcon={<IconThumbDown />}
-              className={styles.voteAgainst}
-              text={messages.voteAgainst}
-              type={ButtonType.RED}
-              onClick={onVoteAgainst}
-              isDepressed={currentVote === Vote.No}
-              isDisabled={currentVote === Vote.No}
-            />
-          </div>
-        )}
+      {isUserStaker && inProgressProposalSubstate === Outcome.InProgress && (
+        <div className={styles.vote}>
+          <Button
+            leftIcon={<IconThumbUp />}
+            className={styles.voteFor}
+            text={messages.voteFor}
+            type={ButtonType.GREEN}
+            onClick={onVoteFor}
+            isDepressed={currentVote === Vote.Yes}
+            isDisabled={currentVote === Vote.Yes}
+          />
+          <Button
+            leftIcon={<IconThumbDown />}
+            className={styles.voteAgainst}
+            text={messages.voteAgainst}
+            type={ButtonType.RED}
+            onClick={onVoteAgainst}
+            isDepressed={currentVote === Vote.No}
+            isDisabled={currentVote === Vote.No}
+          />
+        </div>
+      )}
     </div>
   )
 }
@@ -202,11 +196,9 @@ const ProposalHero: React.FC<ProposalHeroProps> = ({
 
   const isActive =
     proposal?.outcome === Outcome.InProgress &&
-    (inProgressProposalSubstate === InProgressOutcomeSubstates.InProgress ||
-      inProgressProposalSubstate ===
-        InProgressOutcomeSubstates.InProgressAwaitingExecution ||
-      inProgressProposalSubstate ===
-        InProgressOutcomeSubstates.InProgressExecutionDelay)
+    (inProgressProposalSubstate === Outcome.InProgress ||
+      inProgressProposalSubstate === Outcome.InProgressAwaitingExecution ||
+      inProgressProposalSubstate === Outcome.InProgressExecutionDelay)
 
   const evaluatedBlockTimestamp = proposal?.evaluatedBlock?.timestamp ?? null
 

--- a/src/components/ProposalHero/ProposalHero.tsx
+++ b/src/components/ProposalHero/ProposalHero.tsx
@@ -37,7 +37,6 @@ const messages = {
   voteFor: 'Vote For',
   voteAgainst: 'Vote Against',
   timeRemaining: 'Est. Time Remaining',
-  votingEnded: 'Voting Ended',
   targetBlock: 'Target Block',
   notVoted: 'NOT-VOTED',
   voted: 'VOTED',
@@ -80,18 +79,13 @@ const VoteCTA: React.FC<VoteCTAProps> = ({
 
   return (
     <div className={styles.voteCTA}>
-      <div className={styles.statusContainer}>
-        {inProgressProposalSubstate === Outcome.InProgress && timeRemaining !== null && (
+      <div className={styles.timeRemaining}>
+        {timeRemaining !== null && (
           <>
             <div className={styles.title}>{messages.timeRemaining}</div>
-            <div className={styles.message}>
+            <div className={styles.time}>
               {getHumanReadableTime(timeRemaining)}
             </div>
-          </>
-        )}
-        {inProgressProposalSubstate !== Outcome.InProgress && (
-          <>
-            <div className={styles.message}>{messages.votingEnded}</div>
           </>
         )}
         <div className={styles.blocks}>

--- a/src/components/ProposalHero/ProposalHero.tsx
+++ b/src/components/ProposalHero/ProposalHero.tsx
@@ -164,7 +164,7 @@ const ExecuteProposalCTA: React.FC<ExecuteProposalCTAProps> = ({
       <div className={styles.voteStatusContainer}>
         <div className={styles.title}>{messages.awaitExecuteProposal}</div>
       </div>
-        <div>
+      <div>
         <Button
           text={messages.executeProposal}
           type={ButtonType.GREEN}
@@ -337,7 +337,9 @@ const ProposalHero: React.FC<ProposalHeroProps> = ({
             <div className={styles.left}>
               <div className={styles.description}>{proposal.name}</div>
               <div className={styles.info}>
-                <ProposalStatusBadge outcome={inProgressProposalSubstate || proposal.outcome} />
+                <ProposalStatusBadge
+                  outcome={inProgressProposalSubstate || proposal.outcome}
+                />
                 <div className={styles.id}>
                   {leftPadZero(proposal.proposalId, 3)}
                 </div>

--- a/src/components/ProposalHero/ProposalHero.tsx
+++ b/src/components/ProposalHero/ProposalHero.tsx
@@ -125,12 +125,6 @@ const ExecutionDelayCTA: React.FC<ExecutionDelayCTAProps> = ({
     votingDeadlineBlock
   )
 
-  const { status: userStatus, user: accountUser } = useAccountUser()
-  const activeStake = accountUser
-    ? getActiveStake(accountUser)
-    : Utils.toBN('0')
-  const isUserStaker = userStatus === Status.Success && !activeStake.isZero()
-
   return (
     <div className={styles.voteCTA}>
       <div className={styles.voteStatusContainer}>
@@ -146,16 +140,14 @@ const ExecutionDelayCTA: React.FC<ExecutionDelayCTAProps> = ({
           <span>{`${messages.targetBlock}: ${targetBlock}`}</span>
         </div>
       </div>
-      {isUserStaker && (
-        <div>
-          <Button
-            text={messages.executeProposal}
-            type={ButtonType.GREEN}
-            isDepressed={true}
-            isDisabled={true}
-          />
-        </div>
-      )}
+      <div>
+        <Button
+          text={messages.executeProposal}
+          type={ButtonType.GREEN}
+          isDepressed={true}
+          isDisabled={true}
+        />
+      </div>
     </div>
   )
 }
@@ -167,26 +159,18 @@ type ExecuteProposalCTAProps = {
 const ExecuteProposalCTA: React.FC<ExecuteProposalCTAProps> = ({
   onExecuteProposal
 }) => {
-  const { status: userStatus, user: accountUser } = useAccountUser()
-  const activeStake = accountUser
-    ? getActiveStake(accountUser)
-    : Utils.toBN('0')
-  const isUserStaker = userStatus === Status.Success && !activeStake.isZero()
-
   return (
     <div className={styles.voteCTA}>
       <div className={styles.voteStatusContainer}>
         <div className={styles.title}>{messages.awaitExecuteProposal}</div>
       </div>
-      {isUserStaker && (
         <div>
-          <Button
-            text={messages.executeProposal}
-            type={ButtonType.GREEN}
-            onClick={onExecuteProposal}
-          />
-        </div>
-      )}
+        <Button
+          text={messages.executeProposal}
+          type={ButtonType.GREEN}
+          onClick={onExecuteProposal}
+        />
+      </div>
     </div>
   )
 }
@@ -353,7 +337,7 @@ const ProposalHero: React.FC<ProposalHeroProps> = ({
             <div className={styles.left}>
               <div className={styles.description}>{proposal.name}</div>
               <div className={styles.info}>
-                <ProposalStatusBadge outcome={proposal.outcome} />
+                <ProposalStatusBadge outcome={inProgressProposalSubstate || proposal.outcome} />
                 <div className={styles.id}>
                   {leftPadZero(proposal.proposalId, 3)}
                 </div>

--- a/src/components/ProposalHero/ProposalHero.tsx
+++ b/src/components/ProposalHero/ProposalHero.tsx
@@ -175,7 +175,7 @@ const ExecuteProposalCTA: React.FC<ExecuteProposalCTAProps> = ({
 
   return (
     <div className={styles.voteCTA}>
-      <div className={styles.statusContainer}>
+      <div className={styles.voteStatusContainer}>
         <div className={styles.title}>{messages.awaitExecuteProposal}</div>
       </div>
       {isUserStaker && (
@@ -337,8 +337,7 @@ const ProposalHero: React.FC<ProposalHeroProps> = ({
           )}
           {isActive &&
             inProgressProposalSubstate === Outcome.InProgressExecutionDelay &&
-            proposalMilestoneBlocks &&
-            proposalMilestoneBlocks.votingDeadlineBlock && (
+            proposalMilestoneBlocks?.votingDeadlineBlock && (
               <ExecutionDelayCTA
                 votingDeadlineBlock={
                   proposalMilestoneBlocks.votingDeadlineBlock

--- a/src/components/ProposalHero/ProposalHero.tsx
+++ b/src/components/ProposalHero/ProposalHero.tsx
@@ -163,8 +163,6 @@ const ProposalHero: React.FC<ProposalHeroProps> = ({
 
   const { status, error, submitVote } = useSubmitVote(reset)
 
-  const { executeProposal } = useExecuteProposal(reset)
-
   const [currentVote, setCurrentVote] = useState<Vote>(userVote)
   const [newVote, setNewVote] = useState<Vote>(userVote)
   useEffect(() => {
@@ -183,10 +181,6 @@ const ProposalHero: React.FC<ProposalHeroProps> = ({
     setNewVote(Vote.No)
     setIsConfirmModalOpen(true)
   }, [setNewVote, setIsConfirmModalOpen])
-
-  const onExecuteProposal = useCallback(() => {
-    executeProposal(proposal.proposalId)
-  }, [executeProposal, proposal])
 
   const onConfirm = useCallback(() => {
     if (!!newVote) {
@@ -230,6 +224,39 @@ const ProposalHero: React.FC<ProposalHeroProps> = ({
   const hasMetQuorum = proposal
     ? totalMagnitudeVoted.gte(proposal.quorum)
     : false
+
+  // execute proposal
+  const {
+    executeProposal,
+    error: executeError,
+    status: executeStatus
+  } = useExecuteProposal(reset)
+  const [isExecuteConfirmModalOpen, setIsExecuteConfirmModalOpen] = useState(
+    false
+  )
+  const onExecuteCloseConfirm = useCallback(
+    () => setIsExecuteConfirmModalOpen(false),
+    []
+  )
+
+  const onExecuteProposal = useCallback(() => {
+    setIsExecuteConfirmModalOpen(true)
+  }, [setIsExecuteConfirmModalOpen])
+
+  const onExecuteConfirm = useCallback(() => {
+    executeProposal(proposal.proposalId)
+  }, [executeProposal, proposal])
+
+  useEffect(() => {
+    setIsExecuteConfirmModalOpen(false)
+    setReset(true)
+  }, [setIsExecuteConfirmModalOpen, setReset])
+
+  const confirmExecuteProposalBox = (
+    <StandaloneBox className={styles.confirmation}>
+      {`Exceuting proposal ${proposal?.proposalId}`}
+    </StandaloneBox>
+  )
 
   return (
     <Paper className={styles.container}>
@@ -313,6 +340,7 @@ const ProposalHero: React.FC<ProposalHeroProps> = ({
           <Loading />
         </div>
       )}
+      {/* submit vote modal */}
       <ConfirmTransactionModal
         withArrow={false}
         isOpen={isConfirmModalOpen}
@@ -321,6 +349,16 @@ const ProposalHero: React.FC<ProposalHeroProps> = ({
         topBox={submitVoteBox}
         error={error}
         status={status}
+      />
+      {/* execute proposal modal */}
+      <ConfirmTransactionModal
+        withArrow={false}
+        isOpen={isExecuteConfirmModalOpen}
+        onClose={onExecuteCloseConfirm}
+        onConfirm={onExecuteConfirm}
+        topBox={confirmExecuteProposalBox}
+        error={executeError}
+        status={executeStatus}
       />
     </Paper>
   )

--- a/src/components/ProposalHero/ProposalHero.tsx
+++ b/src/components/ProposalHero/ProposalHero.tsx
@@ -37,6 +37,7 @@ const messages = {
   voteFor: 'Vote For',
   voteAgainst: 'Vote Against',
   timeRemaining: 'Est. Time Remaining',
+  votingEnded: 'Voting Ended',
   targetBlock: 'Target Block',
   notVoted: 'NOT-VOTED',
   voted: 'VOTED',
@@ -79,13 +80,18 @@ const VoteCTA: React.FC<VoteCTAProps> = ({
 
   return (
     <div className={styles.voteCTA}>
-      <div className={styles.timeRemaining}>
-        {timeRemaining !== null && (
+      <div className={styles.statusContainer}>
+        {inProgressProposalSubstate === Outcome.InProgress && timeRemaining !== null && (
           <>
             <div className={styles.title}>{messages.timeRemaining}</div>
-            <div className={styles.time}>
+            <div className={styles.message}>
               {getHumanReadableTime(timeRemaining)}
             </div>
+          </>
+        )}
+        {inProgressProposalSubstate !== Outcome.InProgress && (
+          <>
+            <div className={styles.message}>{messages.votingEnded}</div>
           </>
         )}
         <div className={styles.blocks}>

--- a/src/components/ProposalHero/ProposalHero.tsx
+++ b/src/components/ProposalHero/ProposalHero.tsx
@@ -59,7 +59,7 @@ type VoteCTAProps = {
   onExecuteProposal: () => void
   currentVote: Vote
   submissionBlock: number
-  inProgressProposalSubstate: InProgressOutcomeSubstates
+  inProgressProposalSubstate: null | InProgressOutcomeSubstates
 }
 
 const VoteCTA: React.FC<VoteCTAProps> = ({
@@ -205,12 +205,15 @@ const ProposalHero: React.FC<ProposalHeroProps> = ({
   const amountAbstained = useAmountAbstained(proposal) || Utils.toBN('0')
 
   const inProgressProposalSubstate = useGetInProgressProposalSubstate(proposal)
+
   const isActive =
-    inProgressProposalSubstate === InProgressOutcomeSubstates.InProgress ||
-    inProgressProposalSubstate ===
-      InProgressOutcomeSubstates.InProgressAwaitingExecution ||
-    inProgressProposalSubstate ===
-      InProgressOutcomeSubstates.InProgressExecutionDelay
+    proposal?.outcome === Outcome.InProgress &&
+    (inProgressProposalSubstate === InProgressOutcomeSubstates.InProgress ||
+      inProgressProposalSubstate ===
+        InProgressOutcomeSubstates.InProgressAwaitingExecution ||
+      inProgressProposalSubstate ===
+        InProgressOutcomeSubstates.InProgressExecutionDelay)
+
   const evaluatedBlockTimestamp = proposal?.evaluatedBlock?.timestamp ?? null
 
   const submitVoteBox = (

--- a/src/components/ProposalHero/ProposalHero.tsx
+++ b/src/components/ProposalHero/ProposalHero.tsx
@@ -204,12 +204,7 @@ const ProposalHero: React.FC<ProposalHeroProps> = ({
 
   const amountAbstained = useAmountAbstained(proposal) || Utils.toBN('0')
 
-  // const inVotingPeriod = useInVotingPeriod(proposal)
-  // console.log('inVotingPeriod', inVotingPeriod)
-  // const canExecuteProposal = useCanExecuteProposal(proposal)
-  // console.log('canExecuteProposal', canExecuteProposal)
   const inProgressProposalSubstate = useGetInProgressProposalSubstate(proposal)
-  console.log('inProgressProposalSubstate', inProgressProposalSubstate)
   const isActive =
     inProgressProposalSubstate === InProgressOutcomeSubstates.InProgress ||
     inProgressProposalSubstate ===

--- a/src/components/ProposalStatusBadge/ProposalStatusBadge.module.css
+++ b/src/components/ProposalStatusBadge/ProposalStatusBadge.module.css
@@ -24,7 +24,7 @@
   border: 1px solid var(--neutral-light-4);
 }
 
-.executionPending {
+.pending {
   color: #E8AB57;
   border: 1px solid #E8AB57;
 }

--- a/src/components/ProposalStatusBadge/ProposalStatusBadge.tsx
+++ b/src/components/ProposalStatusBadge/ProposalStatusBadge.tsx
@@ -5,7 +5,9 @@ import { Outcome } from 'types'
 
 const messages = {
   open: 'open',
-  executionPending: 'evaluating',
+  executionPending: 'executing',
+  cooldown: 'cooldown',
+  ready: 'awaiting execution',
   passed: 'passed',
   failed: 'failed'
 }
@@ -13,12 +15,12 @@ const messages = {
 const outcomeMapping = {
   [Outcome.InProgress]: { text: messages.open, style: styles.open },
   [Outcome.InProgressExecutionDelay]: {
-    text: messages.open,
-    style: styles.open
+    text: messages.cooldown,
+    style: styles.pending
   },
   [Outcome.InProgressAwaitingExecution]: {
-    text: messages.open,
-    style: styles.open
+    text: messages.ready,
+    style: styles.pending
   },
   [Outcome.Rejected]: { text: messages.failed, style: styles.failed },
   [Outcome.ApprovedExecuted]: { text: messages.passed, style: styles.passed },
@@ -29,7 +31,7 @@ const outcomeMapping = {
   },
   [Outcome.Evaluating]: {
     text: messages.executionPending,
-    style: styles.executionPending
+    style: styles.pending
   },
   [Outcome.Vetoed]: { text: messages.failed, style: styles.failed },
   [Outcome.TargetContractAddressChanged]: {

--- a/src/components/ProposalStatusBadge/ProposalStatusBadge.tsx
+++ b/src/components/ProposalStatusBadge/ProposalStatusBadge.tsx
@@ -12,6 +12,14 @@ const messages = {
 
 const outcomeMapping = {
   [Outcome.InProgress]: { text: messages.open, style: styles.open },
+  [Outcome.InProgressExecutionDelay]: {
+    text: messages.open,
+    style: styles.open
+  },
+  [Outcome.InProgressAwaitingExecution]: {
+    text: messages.open,
+    style: styles.open
+  },
   [Outcome.Rejected]: { text: messages.failed, style: styles.failed },
   [Outcome.ApprovedExecuted]: { text: messages.passed, style: styles.passed },
   [Outcome.QuorumNotMet]: { text: messages.failed, style: styles.failed },

--- a/src/components/ProposalStatusChip/ProposalStatusChip.tsx
+++ b/src/components/ProposalStatusChip/ProposalStatusChip.tsx
@@ -12,6 +12,8 @@ const messages = {
   [Outcome.ApprovedExecutionFailed]: 'Approved Execution Failed',
   [Outcome.Evaluating]: 'Pending Execution', // This is an internal state that will not ever be set
   [Outcome.InProgress]: 'In Progress', // Chip should not be shown for inProgress
+  [Outcome.InProgressExecutionDelay]: 'Execution Delay',
+  [Outcome.InProgressAwaitingExecution]: 'Awaiting Execution',
   [Outcome.Vetoed]: 'Vetoed',
   [Outcome.TargetContractAddressChanged]: 'Target Contract Address Changed',
   [Outcome.TargetContractCodeHashChanged]: 'Target Contract Code Hash Changed'
@@ -51,6 +53,16 @@ const outcomeMapping = {
   },
   [Outcome.InProgress]: {
     text: messages[Outcome.InProgress],
+    style: styles.pending,
+    icon: Pending
+  },
+  [Outcome.InProgressExecutionDelay]: {
+    text: messages[Outcome.InProgressExecutionDelay],
+    style: styles.pending,
+    icon: Pending
+  },
+  [Outcome.InProgressAwaitingExecution]: {
+    text: messages[Outcome.InProgressAwaitingExecution],
     style: styles.pending,
     icon: Pending
   },

--- a/src/components/ProposalStatusChip/ProposalStatusChip.tsx
+++ b/src/components/ProposalStatusChip/ProposalStatusChip.tsx
@@ -12,8 +12,8 @@ const messages = {
   [Outcome.ApprovedExecutionFailed]: 'Approved Execution Failed',
   [Outcome.Evaluating]: 'Pending Execution', // This is an internal state that will not ever be set
   [Outcome.InProgress]: 'In Progress', // Chip should not be shown for inProgress
-  [Outcome.InProgressExecutionDelay]: 'Execution Delay',
-  [Outcome.InProgressAwaitingExecution]: 'Awaiting Execution',
+  [Outcome.InProgressExecutionDelay]: 'Execution Cooldown',
+  [Outcome.InProgressAwaitingExecution]: 'Proposal Can Be Executed',
   [Outcome.Vetoed]: 'Vetoed',
   [Outcome.TargetContractAddressChanged]: 'Target Contract Address Changed',
   [Outcome.TargetContractCodeHashChanged]: 'Target Contract Code Hash Changed'

--- a/src/services/Audius/governance/governance.ts
+++ b/src/services/Audius/governance/governance.ts
@@ -283,6 +283,11 @@ export default class Governance {
     })
   }
 
+  async evaluateProposalOutcome({ proposalId }: { proposalId: ProposalId }) {
+    await this.aud.hasPermissions(Permission.WRITE)
+    await this.getContract().evaluateProposalOutcome(proposalId)
+  }
+
   // Helpers
 
   getContract() {

--- a/src/store/actions/executeProposal.ts
+++ b/src/store/actions/executeProposal.ts
@@ -3,7 +3,7 @@ import { useDispatch } from 'react-redux'
 import { ThunkAction } from 'redux-thunk'
 import { Action } from 'redux'
 
-import { Status, Vote } from 'types'
+import { Status } from 'types'
 import Audius from 'services/Audius'
 import { AppState } from 'store/types'
 import { fetchProposal } from 'store/cache/proposals/hooks'

--- a/src/store/actions/executeProposal.ts
+++ b/src/store/actions/executeProposal.ts
@@ -14,7 +14,6 @@ function executeAudiusProposal(
   setError: (msg: string) => void
 ): ThunkAction<void, AppState, Audius, Action<string>> {
   return async (dispatch, getState, aud) => {
-    console.log('inside executeAudiusProposal')
     setStatus(Status.Loading)
     try {
       await aud.Governance.evaluateProposalOutcome({ proposalId })

--- a/src/store/actions/executeProposal.ts
+++ b/src/store/actions/executeProposal.ts
@@ -1,0 +1,53 @@
+import { useState, useCallback, useEffect } from 'react'
+import { useDispatch } from 'react-redux'
+import { ThunkAction } from 'redux-thunk'
+import { Action } from 'redux'
+
+import { Status, Vote } from 'types'
+import Audius from 'services/Audius'
+import { AppState } from 'store/types'
+import { fetchProposal } from 'store/cache/proposals/hooks'
+
+function executeAudiusProposal(
+  proposalId: number,
+  setStatus: (status: Status) => void,
+  setError: (msg: string) => void
+): ThunkAction<void, AppState, Audius, Action<string>> {
+  return async (dispatch, getState, aud) => {
+    console.log('inside executeAudiusProposal')
+    setStatus(Status.Loading)
+    try {
+      await aud.Governance.evaluateProposalOutcome({ proposalId })
+
+      // Repull proposal
+      await dispatch(fetchProposal(proposalId))
+
+      setStatus(Status.Success)
+    } catch (err) {
+      setStatus(Status.Failure)
+      setError(err.message)
+    }
+  }
+}
+
+export const useExecuteProposal = (shouldReset?: boolean) => {
+  const [status, setStatus] = useState<undefined | Status>()
+  const [error, setError] = useState<string>('')
+  const dispatch = useDispatch()
+
+  useEffect(() => {
+    if (shouldReset) {
+      setStatus(undefined)
+      setError('')
+    }
+  }, [shouldReset, setStatus, setError])
+
+  const executeProposal = useCallback(
+    (proposalId: number) => {
+      dispatch(executeAudiusProposal(proposalId, setStatus, setError))
+    },
+    [dispatch, setStatus, setError]
+  )
+
+  return { status, error, executeProposal }
+}

--- a/src/store/cache/proposals/hooks.ts
+++ b/src/store/cache/proposals/hooks.ts
@@ -242,27 +242,6 @@ export const useAmountAbstained = (proposal: Proposal) => {
   return totalStaked.sub(voteMagnitude)
 }
 
-export const useCanExecuteProposal = (proposal: Proposal) => {
-  const { votingPeriod } = useVotingPeriod()
-  const { executionDelay } = useExecutionDelay()
-  const currentBlockNumber = useEthBlockNumber()
-
-  if (!proposal || !proposal.submissionBlockNumber) return false
-
-  const { submissionBlockNumber } = proposal
-  if (
-    !submissionBlockNumber ||
-    !votingPeriod ||
-    !executionDelay ||
-    !currentBlockNumber
-  )
-    return false
-  const canExecuteProposal =
-    currentBlockNumber >= submissionBlockNumber + votingPeriod + executionDelay
-
-  return canExecuteProposal
-}
-
 /**
  * Although a proposal can be InProgress, there's several substates like:
  * InProgress - can be voted on

--- a/src/store/cache/proposals/hooks.ts
+++ b/src/store/cache/proposals/hooks.ts
@@ -254,8 +254,7 @@ export const useGetInProgressProposalSubstate = (proposal: Proposal) => {
   const { executionDelay } = useExecutionDelay()
   const currentBlockNumber = useEthBlockNumber()
 
-  if (!proposal || !proposal.submissionBlockNumber)
-    return InProgressOutcomeSubstates.InProgress
+  if (!proposal || !proposal.submissionBlockNumber) return null
 
   const { submissionBlockNumber } = proposal
   if (
@@ -264,7 +263,7 @@ export const useGetInProgressProposalSubstate = (proposal: Proposal) => {
     !executionDelay ||
     !currentBlockNumber
   )
-    return InProgressOutcomeSubstates.InProgress
+    return null
 
   if (
     currentBlockNumber >=

--- a/src/store/cache/proposals/hooks.ts
+++ b/src/store/cache/proposals/hooks.ts
@@ -286,18 +286,11 @@ export const useGetInProgressProposalSubstate = (proposal: Proposal) => {
 export const useProposalMilestoneBlocks = (proposal: Proposal) => {
   const { votingPeriod } = useVotingPeriod()
   const { executionDelay } = useExecutionDelay()
-  const currentBlockNumber = useEthBlockNumber()
 
   if (!proposal || !proposal.submissionBlockNumber) return null
 
   const { submissionBlockNumber } = proposal
-  if (
-    !submissionBlockNumber ||
-    !votingPeriod ||
-    !executionDelay ||
-    !currentBlockNumber
-  )
-    return null
+  if (!submissionBlockNumber || !votingPeriod || !executionDelay) return null
 
   return {
     submissionBlock: submissionBlockNumber,

--- a/src/store/cache/proposals/hooks.ts
+++ b/src/store/cache/proposals/hooks.ts
@@ -12,12 +12,7 @@ import {
   setVotingPeriod
 } from './slice'
 import { useEffect } from 'react'
-import {
-  Proposal,
-  ProposalEvent,
-  Outcome,
-  InProgressOutcomeSubstates
-} from 'types'
+import { Proposal, ProposalEvent, Outcome } from 'types'
 import {
   useTotalStaked,
   useDispatchBasedOnBlockNumber,
@@ -269,8 +264,8 @@ export const useGetInProgressProposalSubstate = (proposal: Proposal) => {
     currentBlockNumber >=
     submissionBlockNumber + votingPeriod + executionDelay
   )
-    return InProgressOutcomeSubstates.InProgressAwaitingExecution
+    return Outcome.InProgressAwaitingExecution
   else if (currentBlockNumber >= submissionBlockNumber + votingPeriod)
-    return InProgressOutcomeSubstates.InProgressExecutionDelay
-  else return InProgressOutcomeSubstates.InProgress
+    return Outcome.InProgressExecutionDelay
+  else return Outcome.InProgress
 }

--- a/src/store/cache/proposals/hooks.ts
+++ b/src/store/cache/proposals/hooks.ts
@@ -269,11 +269,12 @@ export const useGetInProgressProposalSubstate = (proposal: Proposal) => {
   if (
     currentBlockNumber >=
     submissionBlockNumber + votingPeriod + executionDelay
-  )
+  ) {
     return Outcome.InProgressAwaitingExecution
-  else if (currentBlockNumber >= submissionBlockNumber + votingPeriod)
+  } else if (currentBlockNumber >= submissionBlockNumber + votingPeriod) {
     return Outcome.InProgressExecutionDelay
-  else return Outcome.InProgress
+  }
+  return Outcome.InProgress
 }
 
 /**

--- a/src/store/cache/proposals/hooks.ts
+++ b/src/store/cache/proposals/hooks.ts
@@ -7,15 +7,22 @@ import { AppState } from 'store/types'
 import {
   setActiveProposals,
   setAllProposals,
+  setExecutionDelay,
   setProposal,
   setVotingPeriod
 } from './slice'
 import { useEffect } from 'react'
-import { Proposal, ProposalEvent, Outcome } from 'types'
+import {
+  Proposal,
+  ProposalEvent,
+  Outcome,
+  InProgressOutcomeSubstates
+} from 'types'
 import {
   useTotalStaked,
   useDispatchBasedOnBlockNumber,
-  useTimeRemaining
+  useTimeRemaining,
+  useEthBlockNumber
 } from 'store/cache/protocol/hooks'
 
 // -------------------------------- Selectors  --------------------------------
@@ -45,6 +52,9 @@ export const getProposal = (
 
 export const getVotingPeriod = (state: AppState) =>
   state.cache.proposals.votingPeriod
+
+export const getExecutionDelay = (state: AppState) =>
+  state.cache.proposals.executionDelay
 
 // -------------------------------- Thunk Actions  --------------------------------
 
@@ -143,6 +153,18 @@ export function fetchVotingPeriod(): ThunkAction<
   }
 }
 
+export function fetchExecutionDelay(): ThunkAction<
+  void,
+  AppState,
+  Audius,
+  Action<string>
+> {
+  return async (dispatch, getState, aud) => {
+    const executionDelay = await aud.Governance.getExecutionDelay()
+    dispatch(setExecutionDelay({ executionDelay }))
+  }
+}
+
 // -------------------------------- Hooks  --------------------------------
 
 export const useProposals = () => {
@@ -195,6 +217,18 @@ export const useVotingPeriod = () => {
   return { votingPeriod }
 }
 
+export const useExecutionDelay = () => {
+  const executionDelay = useSelector(getExecutionDelay)
+  const dispatch = useDispatch()
+  useEffect(() => {
+    if (!executionDelay) {
+      dispatch(fetchExecutionDelay())
+    }
+  }, [dispatch, executionDelay])
+
+  return { executionDelay }
+}
+
 export const useProposalTimeRemaining = (submissionBlock: number) => {
   const { votingPeriod } = useVotingPeriod()
   const remaining = useTimeRemaining(submissionBlock, votingPeriod)
@@ -206,4 +240,59 @@ export const useAmountAbstained = (proposal: Proposal) => {
   if (!proposal || !totalStaked) return null
   const voteMagnitude = proposal.voteMagnitudeYes.add(proposal.voteMagnitudeNo)
   return totalStaked.sub(voteMagnitude)
+}
+
+export const useCanExecuteProposal = (proposal: Proposal) => {
+  const { votingPeriod } = useVotingPeriod()
+  const { executionDelay } = useExecutionDelay()
+  const currentBlockNumber = useEthBlockNumber()
+
+  if (!proposal || !proposal.submissionBlockNumber) return false
+
+  const { submissionBlockNumber } = proposal
+  if (
+    !submissionBlockNumber ||
+    !votingPeriod ||
+    !executionDelay ||
+    !currentBlockNumber
+  )
+    return false
+  const canExecuteProposal =
+    currentBlockNumber >= submissionBlockNumber + votingPeriod + executionDelay
+
+  return canExecuteProposal
+}
+
+/**
+ * Although a proposal can be InProgress, there's several substates like:
+ * InProgress - can be voted on
+ * InProgressExecutionDelay - cannot be voted on, but not yet ready for execution
+ * InProgressAwaitingExecution - can be executed
+ * @param proposal Proposal object
+ */
+export const useGetInProgressProposalSubstate = (proposal: Proposal) => {
+  const { votingPeriod } = useVotingPeriod()
+  const { executionDelay } = useExecutionDelay()
+  const currentBlockNumber = useEthBlockNumber()
+
+  if (!proposal || !proposal.submissionBlockNumber)
+    return InProgressOutcomeSubstates.InProgress
+
+  const { submissionBlockNumber } = proposal
+  if (
+    !submissionBlockNumber ||
+    !votingPeriod ||
+    !executionDelay ||
+    !currentBlockNumber
+  )
+    return InProgressOutcomeSubstates.InProgress
+
+  if (
+    currentBlockNumber >=
+    submissionBlockNumber + votingPeriod + executionDelay
+  )
+    return InProgressOutcomeSubstates.InProgressAwaitingExecution
+  else if (currentBlockNumber >= submissionBlockNumber + votingPeriod)
+    return InProgressOutcomeSubstates.InProgressExecutionDelay
+  else return InProgressOutcomeSubstates.InProgress
 }

--- a/src/store/cache/proposals/hooks.ts
+++ b/src/store/cache/proposals/hooks.ts
@@ -230,6 +230,12 @@ export const useProposalTimeRemaining = (submissionBlock: number) => {
   return remaining
 }
 
+export const useExecutionDelayTimeRemaining = (votingDeadlineBlock: number) => {
+  const { executionDelay } = useExecutionDelay()
+  const remaining = useTimeRemaining(votingDeadlineBlock, executionDelay)
+  return remaining
+}
+
 export const useAmountAbstained = (proposal: Proposal) => {
   const totalStaked = useTotalStaked()
   if (!proposal || !totalStaked) return null
@@ -268,4 +274,35 @@ export const useGetInProgressProposalSubstate = (proposal: Proposal) => {
   else if (currentBlockNumber >= submissionBlockNumber + votingPeriod)
     return Outcome.InProgressExecutionDelay
   else return Outcome.InProgress
+}
+
+/**
+ * Calculate the block numbers for major milestones along a proposal's lifetime
+ * submissionBlock - block where the submission occurred
+ * votingDeadlineBlock - block before which all voting must occure
+ * executionDeadlineBlock - block after which a proposal can be executed
+ * @param proposal Proposal object
+ */
+export const useProposalMilestoneBlocks = (proposal: Proposal) => {
+  const { votingPeriod } = useVotingPeriod()
+  const { executionDelay } = useExecutionDelay()
+  const currentBlockNumber = useEthBlockNumber()
+
+  if (!proposal || !proposal.submissionBlockNumber) return null
+
+  const { submissionBlockNumber } = proposal
+  if (
+    !submissionBlockNumber ||
+    !votingPeriod ||
+    !executionDelay ||
+    !currentBlockNumber
+  )
+    return null
+
+  return {
+    submissionBlock: submissionBlockNumber,
+    votingDeadlineBlock: submissionBlockNumber + votingPeriod,
+    executionDeadlineBlock:
+      submissionBlockNumber + votingPeriod + executionDelay
+  }
 }

--- a/src/store/cache/proposals/slice.ts
+++ b/src/store/cache/proposals/slice.ts
@@ -11,13 +11,16 @@ export type State = {
   resolvedProposals: number[] | null
   // Voting period to determine when votes are due
   votingPeriod: number | null
+  // Execution delay after voting period but before being able to execute a governance proposal
+  executionDelay: number | null
 }
 
 export const initialState: State = {
   activeProposals: null,
   allProposals: {},
   resolvedProposals: null,
-  votingPeriod: null
+  votingPeriod: null,
+  executionDelay: null
 }
 
 type SetActiveProposals = {
@@ -34,6 +37,10 @@ type SetProposal = {
 
 type SetVotingPeriod = {
   votingPeriod: number
+}
+
+type SetExecutionDelay = {
+  executionDelay: number
 }
 
 const slice = createSlice({
@@ -64,6 +71,10 @@ const slice = createSlice({
     setVotingPeriod: (state, action: PayloadAction<SetVotingPeriod>) => {
       const { votingPeriod } = action.payload
       state.votingPeriod = votingPeriod
+    },
+    setExecutionDelay: (state, action: PayloadAction<SetExecutionDelay>) => {
+      const { executionDelay } = action.payload
+      state.executionDelay = executionDelay
     }
   }
 })
@@ -72,7 +83,8 @@ export const {
   setActiveProposals,
   setAllProposals,
   setProposal,
-  setVotingPeriod
+  setVotingPeriod,
+  setExecutionDelay
 } = slice.actions
 
 export default slice.reducer

--- a/src/types.ts
+++ b/src/types.ts
@@ -123,6 +123,8 @@ export type VoteEvent = {
 
 export enum Outcome {
   InProgress = 'InProgress', // Proposal is active and can be voted on.
+  InProgressExecutionDelay = 'InProgressExecutionDelay', //Proposal is active but cannot be voted on because it's in execution delay
+  InProgressAwaitingExecution = 'InProgressAwaitingExecution', //Proposal has passed execution delay and can be executed
   Rejected = 'Rejected', // Proposal votingPeriod has closed and vote failed to pass. Proposal will not be executed.
   ApprovedExecuted = 'ApprovedExecuted', // Proposal votingPeriod has closed and vote passed. Proposal was successfully executed.
   QuorumNotMet = 'QuorumNotMet', // Proposal votingPeriod has closed and votingQuorumPercent was not met. Proposal will not be executed.
@@ -131,12 +133,6 @@ export enum Outcome {
   Vetoed = 'Vetoed', // Proposal was vetoed by Guardian.
   TargetContractAddressChanged = 'TargetContractAddressChanged', // Proposal considered invalid since target contract address changed
   TargetContractCodeHashChanged = 'TargetContractCodeHashChanged' // Proposal considered invalid since code has at target contract address has changed
-}
-
-export enum InProgressOutcomeSubstates {
-  InProgress = 'InProgress', // Proposal is active and can be voted on.
-  InProgressExecutionDelay = 'InProgressExecutionDelay', //Proposal is active but cannot be voted on because it's in execution delay
-  InProgressAwaitingExecution = 'InProgressAwaitingExecution' //Proposal has passed execution delay and can be executed
 }
 
 export type ProposalId = number

--- a/src/types.ts
+++ b/src/types.ts
@@ -133,6 +133,12 @@ export enum Outcome {
   TargetContractCodeHashChanged = 'TargetContractCodeHashChanged' // Proposal considered invalid since code has at target contract address has changed
 }
 
+export enum InProgressOutcomeSubstates {
+  InProgress = 'InProgress', // Proposal is active and can be voted on.
+  InProgressExecutionDelay = 'InProgressExecutionDelay', //Proposal is active but cannot be voted on because it's in execution delay
+  InProgressAwaitingExecution = 'InProgressAwaitingExecution' //Proposal has passed execution delay and can be executed
+}
+
 export type ProposalId = number
 
 export type Proposal = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -123,7 +123,7 @@ export type VoteEvent = {
 
 export enum Outcome {
   InProgress = 'InProgress', // Proposal is active and can be voted on.
-  InProgressExecutionDelay = 'InProgressExecutionDelay', //Proposal is active but cannot be voted on because it's in execution delay
+  InProgressExecutionDelay = 'InProgressExecutionDelay', // Proposal is active but cannot be voted on because it's in execution delay
   InProgressAwaitingExecution = 'InProgressAwaitingExecution', //Proposal has passed execution delay and can be executed
   Rejected = 'Rejected', // Proposal votingPeriod has closed and vote failed to pass. Proposal will not be executed.
   ApprovedExecuted = 'ApprovedExecuted', // Proposal votingPeriod has closed and vote passed. Proposal was successfully executed.


### PR DESCRIPTION
My attempt and fixing the Governance voting states and adding an execute button I did yesterday in case we needed to fast track this. Currently what happens in the UI is it only shows you the the submit vote buttons, regardless of whether the proposal is in the voting period, execution delay or is awaiting execution. So not only is there not Execute Proposal button but it still shows you the ability to vote, even after the voting period has passed.

I added substates to "In Progress" so the interface can distinguish these actions and they behave in the following ways:
When voting is allowed, show the voting buttons
After voting has ended but before execution, disable the buttons
After execution is allowed, show the Execute Proposal button

What's left to be done?
Execute Proposal button works, but doesn't show the confirm modal
No "Est Time Remaining" for execution delay
Probably want to display some kind of tag to show current proposal In Progress substatus


During voting period
![image](https://user-images.githubusercontent.com/295938/115477437-e5e3fe00-a211-11eb-9f7b-0ae8847c1d89.png)

After voting before execution delay
![image](https://user-images.githubusercontent.com/295938/115478735-c3071900-a214-11eb-9f50-83f970090489.png)


During execution delay
![image](https://user-images.githubusercontent.com/295938/115477820-c5687380-a212-11eb-86ba-648c63deeec1.png)

When eligible to execute
![image](https://user-images.githubusercontent.com/295938/115478091-5a6b6c80-a213-11eb-9cb8-8989617d417c.png)
