### PR TITLE
Add validBounds and disable claims if out of bounds

### DIFF
--- a/src/components/Button/Button.module.css
+++ b/src/components/Button/Button.module.css
@@ -146,3 +146,20 @@
 .btnContainer .isDisabled svg {
   opacity: .5;
 }
+
+.btnContainer .isDisabled,
+.btnContainer .isDisabled:hover,
+.btnContainer .isDisabled:active {
+  cursor: default;
+  transform: scale3d(1, 1, 1) !important;
+}
+
+.btnContainer .isDisabled,
+.btnContainer .isDisabled:hover,
+.btnContainer .isDisabled:active {
+  background: #696D88 !important;
+}
+
+.btnContainer .isDisabled .isTextDisabled {
+  color: var(--static-white);
+}

--- a/src/components/Delegate/Delegate.tsx
+++ b/src/components/Delegate/Delegate.tsx
@@ -139,7 +139,7 @@ const DelegateSection: React.FC<DelegateSectionProps> = ({
           <Tooltip
             position={Position.TOP}
             text={messages.pendingClaimDisabled}
-            isDisabled={isIncreaseDelegationDisabled}
+            isDisabled={!isIncreaseDelegationDisabled}
             className={styles.delegateBtnTooltip}
           >
             <IncreaseDelegation
@@ -155,7 +155,7 @@ const DelegateSection: React.FC<DelegateSectionProps> = ({
                 ? messages.pendingDecreaseDisabled
                 : messages.pendingClaimDisabled
             }
-            isDisabled={isDecreaseDelegationDisabled}
+            isDisabled={!isDecreaseDelegationDisabled}
             className={styles.delegateBtnTooltip}
           >
             <DecreaseDelegation

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -50,7 +50,7 @@ const Tooltip: React.FC<TooltipProps> = ({
   children,
   text,
   onClick = () => {},
-  isDisabled = true,
+  isDisabled = false,
   position = Position.TOP
 }) => {
   const containerRef = useRef(null)
@@ -93,7 +93,7 @@ const Tooltip: React.FC<TooltipProps> = ({
     return () => window.removeEventListener('scroll', hideOnScroll)
   }, [isHover])
 
-  if (!isDisabled) {
+  if (isDisabled) {
     return <> {children} </>
   }
 

--- a/src/components/UserInfo/UserInfo.tsx
+++ b/src/components/UserInfo/UserInfo.tsx
@@ -25,6 +25,7 @@ import mobileStyles from './UserInfoMobile.module.css'
 import { createStyles } from 'utils/mobile'
 import UserImage from 'components/UserImage'
 import Bounds from 'components/Bounds'
+import Tooltip, { Position } from 'components/Tooltip'
 
 const styles = createStyles({ desktopStyles, mobileStyles })
 
@@ -32,7 +33,8 @@ const messages = {
   delegate: 'DELEGATE',
   undelegate: 'UNDELEGATE',
   claim: 'CLAIM',
-  makeClaim: 'Make Claim'
+  makeClaim: 'Make Claim',
+  claimOutOfBounds: 'Total stake out of bounds'
 }
 
 type UserInfoProps = {
@@ -123,7 +125,13 @@ const UserInfo = ({
   const showUndelegate =
     isLoggedIn && !isOwner && isDoneLoading && !hasClaim && !delegates.isZero()
   const showClaim =
-    isLoggedIn && !isOwner && claimStatus === Status.Success && hasClaim
+    isLoggedIn &&
+    !isOwner &&
+    claimStatus === Status.Success &&
+    hasClaim
+
+  const isClaimDisabled = !isValidBounds
+
   return (
     <>
       {showDelegate && (
@@ -161,20 +169,28 @@ const UserInfo = ({
       )}
       {showClaim && (
         <div className={styles.buttonContainer}>
-          <Button
-            text={messages.claim}
-            type={ButtonType.PRIMARY}
-            onClick={onClick}
-          />
-          <ConfirmTransactionModal
-            isOpen={isOpen}
-            withArrow={false}
-            topBox={makeClaimBox}
-            status={makeClaimStatus}
-            error={makeClaimError}
-            onConfirm={onConfirmClaim}
-            onClose={onClose}
-          />
+          <Tooltip
+            position={Position.TOP}
+            text={messages.claimOutOfBounds}
+            isDisabled={!isClaimDisabled}
+            className={styles.claimDisabledTooltip}
+          >
+            <Button
+              text={messages.claim}
+              type={ButtonType.PRIMARY}
+              onClick={onClick}
+              isDisabled={isClaimDisabled}
+            />
+            <ConfirmTransactionModal
+              isOpen={isOpen}
+              withArrow={false}
+              topBox={makeClaimBox}
+              status={makeClaimStatus}
+              error={makeClaimError}
+              onConfirm={onConfirmClaim}
+              onClose={onClose}
+            />
+          </Tooltip>
         </div>
       )}
       {rank && (

--- a/src/components/UserInfo/UserInfo.tsx
+++ b/src/components/UserInfo/UserInfo.tsx
@@ -125,10 +125,7 @@ const UserInfo = ({
   const showUndelegate =
     isLoggedIn && !isOwner && isDoneLoading && !hasClaim && !delegates.isZero()
   const showClaim =
-    isLoggedIn &&
-    !isOwner &&
-    claimStatus === Status.Success &&
-    hasClaim
+    isLoggedIn && !isOwner && claimStatus === Status.Success && hasClaim
 
   const isClaimDisabled = !isValidBounds
 

--- a/src/containers/User/User.tsx
+++ b/src/containers/User/User.tsx
@@ -106,8 +106,8 @@ const UserPage: React.FC<UserPageProps> = (props: UserPageProps) => {
   const title = isOwner
     ? messages.owner
     : isServiceProvider
-    ? messages.operator
-    : messages.user
+      ? messages.operator
+      : messages.user
   return (
     <Page
       title={title}

--- a/src/containers/User/User.tsx
+++ b/src/containers/User/User.tsx
@@ -106,8 +106,8 @@ const UserPage: React.FC<UserPageProps> = (props: UserPageProps) => {
   const title = isOwner
     ? messages.owner
     : isServiceProvider
-      ? messages.operator
-      : messages.user
+    ? messages.operator
+    : messages.user
   return (
     <Page
       title={title}

--- a/src/store/cache/user/graph/formatter.ts
+++ b/src/store/cache/user/graph/formatter.ts
@@ -1,5 +1,5 @@
 import BN from 'bn.js'
-import { User, ServiceType, Operator } from 'types'
+import { User, ServiceType, Operator, ServiceProvider } from 'types'
 import Audius from 'services/Audius'
 import { FullUser } from './types'
 
@@ -38,16 +38,15 @@ export const formatUser = async (
   if (user.services.length === 0 && user.stakeAmount === '0')
     return formattedUser
 
+  // Note: We must make a contract call to check "validBounds" because that value is not
+  // updated with the graph
+  const serviceProvider: ServiceProvider = await aud.ServiceProviderClient.getServiceProviderDetails(
+    userWallet
+  )
+
   return {
     ...formattedUser,
-    serviceProvider: {
-      deployerCut: parseInt(user.deployerCut),
-      deployerStake: new BN(user.stakeAmount),
-      maxAccountStake: new BN(user?.maxAccountStake ?? 0),
-      minAccountStake: new BN(user?.minAccountStake ?? 0),
-      numberOfEndpoints: user.services?.length ?? 0,
-      validBounds: user.validBounds
-    },
+    serviceProvider,
     delegators:
       user.delegateFrom?.map((delegate, i) => ({
         wallet: aud.toChecksumAddress(delegate.fromUser.id),


### PR DESCRIPTION
## Summary
* Fetch the serviceProviderDetails from on chain to get the validBounds field - it is not indexed from the graph
* Disables the claim btn if the user is out of bounds and adds a tooltip
* Fix the Tooltip component isDisabled field was used incorrectly. 
* Fix btn disabled styles

![Screen Shot 2021-05-12 at 10 39 15 AM](https://user-images.githubusercontent.com/7064122/117995862-a9d32300-b30f-11eb-945b-9132f638a319.png)

