### PR TITLE
Migrate the graph endpoint mainnet

### DIFF
--- a/.env.prod
+++ b/.env.prod
@@ -7,5 +7,5 @@ REACT_APP_QUERY_PROPOSAL_START_BLOCK = 11818009
 REACT_APP_ETH_NETWORK_ID=1
 
 REACT_APP_AUDIUS_URL=https://audius.co
-REACT_APP_GQL_URI=https://api.thegraph.com/subgraphs/name/audius-infra/audius-network-mainnet
-
+REACT_APP_GQL_URI=https://gateway.thegraph.com/api/372f3681a94e4a45867d46cf59423e22/subgraphs/id/0x819fd65026848d710fe40d8c0439f1220e069398-0
+REACT_APP_GQL_BACKUP_URI=https://api.thegraph.com/subgraphs/name/audius-infra/audius-network-mainnet

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,7 @@ import API from 'containers/API'
 import APILeaderboard from 'containers/APILeaderboard'
 import * as routes from 'utils/routes'
 
-import { client, backupClient, createStore } from './store'
+import { client, getBackupClient, createStore } from './store'
 import desktopStyles from './App.module.css'
 import mobileStyles from './AppMobile.module.css'
 import NotFound from 'containers/NotFound'
@@ -42,8 +42,11 @@ const App = () => {
   const [appolloClient, setApolloClient] = useState(client)
   const didClientError = useSelector(getDidGraphError)
   useEffect(() => {
-    if (didClientError && backupClient) {
-      setApolloClient(backupClient)
+    if (didClientError) {
+      const backupClient = getBackupClient()
+      if (backupClient) {
+        setApolloClient(backupClient)
+      }
     }
   }, [didClientError])
   return (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { ApolloProvider } from '@apollo/client'
-import React from 'react'
-import { Provider } from 'react-redux'
+import React, { useEffect, useState } from 'react'
+import { Provider, useSelector } from 'react-redux'
 import { ConnectedRouter } from 'connected-react-router'
 import { Switch, Route } from 'react-router'
 import { createHashHistory } from 'history'
@@ -20,87 +20,103 @@ import API from 'containers/API'
 import APILeaderboard from 'containers/APILeaderboard'
 import * as routes from 'utils/routes'
 
-import { client, createStore } from './store'
+import { client, backupClient, createStore } from './store'
 import desktopStyles from './App.module.css'
 import mobileStyles from './AppMobile.module.css'
 import NotFound from 'containers/NotFound'
 import Proposal from 'containers/Proposal'
 import { createStyles } from 'utils/mobile'
-
+import { getDidGraphError } from 'store/api/hooks'
 const styles = createStyles({ desktopStyles, mobileStyles })
 const history = createHashHistory()
 const store = createStore(history)
 
 const Root = () => (
-  <ApolloProvider client={client}>
-    <Provider store={store}>
-      <ConnectedRouter history={history}>
-        <div className={styles.appContainer}>
-          <Header />
-          <div className={styles.appContent}>
-            <Switch>
-              <Route path={routes.HOME} exact component={Home} />
-              <Route path={routes.SERVICES} exact component={Services} />
-              <Route
-                path={routes.SERVICES_DISCOVERY_PROVIDER}
-                exact
-                component={DiscoveryProviders}
-              />
-              <Route
-                path={routes.SERVICES_DISCOVERY_PROVIDER_NODE}
-                exact
-                component={Node}
-              />
-              <Route
-                path={routes.SERVICES_CONTENT}
-                exact
-                component={ContentNodes}
-              />
-              <Route
-                path={routes.SERVICES_CONTENT_NODE}
-                exact
-                component={Node}
-              />
-              <Route
-                path={routes.SERVICES_SERVICE_PROVIDERS}
-                exact
-                component={ServiceOperators}
-              />
-              <Route
-                path={routes.SERVICES_USERS}
-                exact
-                component={ServiceUsers}
-              />
-              <Route
-                path={routes.SERVICES_ACCOUNT_USER}
-                exact
-                component={User}
-              />
-              <Route
-                path={routes.SERVICES_ACCOUNT_OPERATOR}
-                exact
-                component={User}
-              />
-              <Route path={routes.GOVERNANCE} exact component={Governance} />
-              <Route
-                path={routes.GOVERNANCE_PROPOSAL}
-                exact
-                component={Proposal}
-              />
-              <Route path={routes.ANALYTICS} exact component={Analytics} />
-              <Route path={routes.API} exact component={API} />
-              <Route
-                path={routes.API_LEADERBOARD}
-                exact
-                component={APILeaderboard}
-              />
-              <Route component={NotFound} />
-            </Switch>
-          </div>
-        </div>
-      </ConnectedRouter>
-    </Provider>
-  </ApolloProvider>
+  <Provider store={store}>
+    <App />
+  </Provider>
 )
+
+const App = () => {
+  //  If the client fails, set it to the backup client
+  const [appolloClient, setApolloClient] = useState(client)
+  const didClientError = useSelector(getDidGraphError)
+  useEffect(() => {
+    if (didClientError && backupClient) {
+      setApolloClient(backupClient)
+    }
+  }, [didClientError])
+  return (
+    <Provider store={store}>
+      <ApolloProvider client={appolloClient}>
+        <ConnectedRouter history={history}>
+          <div className={styles.appContainer}>
+            <Header />
+            <div className={styles.appContent}>
+              <Switch>
+                <Route path={routes.HOME} exact component={Home} />
+                <Route path={routes.SERVICES} exact component={Services} />
+                <Route
+                  path={routes.SERVICES_DISCOVERY_PROVIDER}
+                  exact
+                  component={DiscoveryProviders}
+                />
+                <Route
+                  path={routes.SERVICES_DISCOVERY_PROVIDER_NODE}
+                  exact
+                  component={Node}
+                />
+                <Route
+                  path={routes.SERVICES_CONTENT}
+                  exact
+                  component={ContentNodes}
+                />
+                <Route
+                  path={routes.SERVICES_CONTENT_NODE}
+                  exact
+                  component={Node}
+                />
+                <Route
+                  path={routes.SERVICES_SERVICE_PROVIDERS}
+                  exact
+                  component={ServiceOperators}
+                />
+                <Route
+                  path={routes.SERVICES_USERS}
+                  exact
+                  component={ServiceUsers}
+                />
+                <Route
+                  path={routes.SERVICES_ACCOUNT_USER}
+                  exact
+                  component={User}
+                />
+                <Route
+                  path={routes.SERVICES_ACCOUNT_OPERATOR}
+                  exact
+                  component={User}
+                />
+                <Route path={routes.GOVERNANCE} exact component={Governance} />
+                <Route
+                  path={routes.GOVERNANCE_PROPOSAL}
+                  exact
+                  component={Proposal}
+                />
+                <Route path={routes.ANALYTICS} exact component={Analytics} />
+                <Route path={routes.API} exact component={API} />
+                <Route
+                  path={routes.API_LEADERBOARD}
+                  exact
+                  component={APILeaderboard}
+                />
+                <Route component={NotFound} />
+              </Switch>
+            </div>
+          </div>
+        </ConnectedRouter>
+      </ApolloProvider>
+    </Provider>
+  )
+}
 
 export default Root

--- a/src/components/ErrorModal/ErrorModal.tsx
+++ b/src/components/ErrorModal/ErrorModal.tsx
@@ -1,9 +1,7 @@
 import React, { useState, useCallback } from 'react'
 import SimpleBar from 'simplebar-react'
-import clsx from 'clsx'
 import { ButtonType } from '@audius/stems'
 
-import AudiusClient from 'services/Audius'
 import Modal from 'components/Modal'
 import Button from 'components/Button'
 import styles from './ErrorModal.module.css'

--- a/src/hooks/useTotalStaked.ts
+++ b/src/hooks/useTotalStaked.ts
@@ -1,6 +1,7 @@
 import BN from 'bn.js'
-import { useQuery, gql } from '@apollo/client'
+import { gql } from '@apollo/client'
 import { useUsers } from 'store/cache/user/hooks'
+import { useGraphQuery as useQuery } from 'store/api/hooks'
 import getActiveStake from 'utils/activeStake'
 import { Status } from 'types'
 

--- a/src/services/AudiusSubgraph/index.ts
+++ b/src/services/AudiusSubgraph/index.ts
@@ -1,4 +1,5 @@
-import { useQuery, gql } from '@apollo/client'
+import { gql } from '@apollo/client'
+import { useGraphQuery as useQuery } from 'store/api/hooks'
 
 const HEALTH_CHECK = gql`
   query healthCheck($subgraphName: String!) {

--- a/src/store/api/hooks.ts
+++ b/src/store/api/hooks.ts
@@ -1,0 +1,21 @@
+import { useSelector, useDispatch } from 'react-redux'
+import { useQuery } from '@apollo/client'
+import { setDidError } from './slice'
+import { AppState } from 'store/types'
+
+// -------------------------------- Selectors  --------------------------------
+export const getGraphAPI = (state: AppState) => state.api
+export const getDidGraphError = (state: AppState) => state.api.didError
+
+// -------------------------------- Hooks  --------------------------------
+export const useGraphQuery: typeof useQuery = (...args) => {
+  const result = useQuery(...args)
+  const didError = useSelector(getDidGraphError)
+  const dispatch = useDispatch()
+
+  if (!result.loading && !didError && result.error) {
+    dispatch(setDidError())
+  }
+
+  return result
+}

--- a/src/store/api/slice.ts
+++ b/src/store/api/slice.ts
@@ -1,0 +1,26 @@
+import { createSlice } from '@reduxjs/toolkit'
+const gqlBackupUri = process.env.REACT_APP_GQL_BACKUP_URI
+
+export type State = {
+  didError: boolean
+  hasBackupClient: boolean
+}
+
+export const initialState: State = {
+  didError: false,
+  hasBackupClient: !!gqlBackupUri
+}
+
+const slice = createSlice({
+  name: 'api',
+  initialState,
+  reducers: {
+    setDidError: state => {
+      state.didError = true
+    }
+  }
+})
+
+export const { setDidError } = slice.actions
+
+export default slice.reducer

--- a/src/store/cache/user/graph/hooks.ts
+++ b/src/store/cache/user/graph/hooks.ts
@@ -62,8 +62,6 @@ export const useUsers = (status: Status | undefined) => {
     }
   }, [gqlData, dispatch, status])
 
-  console.log({ hasBackupClient, gqlError, didError })
-
   // If there is a fallback, do not return error until the fallback also errors
   if (hasBackupClient && gqlError && !didError) {
     return { error: null }

--- a/src/store/cache/user/graph/queries.ts
+++ b/src/store/cache/user/graph/queries.ts
@@ -2,7 +2,7 @@ import { gql } from '@apollo/client'
 
 export const GET_USERS = gql`
   query users($where: User_filter!, $orderBy: User_orderBy!) {
-    users(where: $where, orderBy: $orderBy, orderDirection: desc) {
+    users(where: $where, orderBy: $orderBy, orderDirection: desc, first: 200) {
       id
       balance
       totalClaimableAmount
@@ -22,6 +22,7 @@ export const GET_USERS = gql`
         orderBy: claimableAmount
         orderDirection: desc
         where: { amount_gt: 0 }
+        first: 200
       ) {
         claimableAmount
         amount
@@ -35,6 +36,7 @@ export const GET_USERS = gql`
         orderBy: claimableAmount
         orderDirection: desc
         where: { amount_gt: 0 }
+        first: 200
       ) {
         claimableAmount
         amount
@@ -115,6 +117,7 @@ export const GET_USER = gql`
         orderBy: claimableAmount
         orderDirection: desc
         where: { amount_gt: 0 }
+        first: 200
       ) {
         claimableAmount
         amount
@@ -128,6 +131,7 @@ export const GET_USER = gql`
         orderBy: claimableAmount
         orderDirection: desc
         where: { amount_gt: 0 }
+        first: 200
       ) {
         claimableAmount
         amount

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -23,21 +23,37 @@ import analytics from 'store/cache/analytics/slice'
 import music from 'store/cache/music/slice'
 import account from 'store/account/slice'
 import pageHistory from 'store/pageHistory/slice'
+import api from 'store/api/slice'
 
 declare global {
   interface Window {
     aud: any
     store: any
     client: ApolloClient<any>
+    hostedClient: ApolloClient<any>
   }
 }
 
 const gqlUri = process.env.REACT_APP_GQL_URI
+const gqlBackupUri = process.env.REACT_APP_GQL_BACKUP_URI
 
 export const client = new ApolloClient({
   uri: gqlUri,
   cache: new InMemoryCache()
 })
+
+let hostedClient = null
+if (gqlBackupUri) {
+  hostedClient = new ApolloClient({
+    uri: gqlBackupUri,
+    cache: new InMemoryCache()
+  })
+
+  window.hostedClient = hostedClient
+}
+
+export const hasBackupClient = !!gqlBackupUri
+export const backupClient = hostedClient
 
 const aud = new Audius()
 window.aud = aud
@@ -50,6 +66,7 @@ const getReducer = (history: History) => {
     router: connectRouter(history),
     pageHistory,
     account,
+    api,
     cache: combineReducers({
       discoveryProvider,
       contentNode,

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,4 +1,8 @@
-import { ApolloClient, InMemoryCache } from '@apollo/client'
+import {
+  ApolloClient,
+  InMemoryCache,
+  NormalizedCacheObject
+} from '@apollo/client'
 import {
   combineReducers,
   createStore as createReduxStore,
@@ -42,18 +46,23 @@ export const client = new ApolloClient({
   cache: new InMemoryCache()
 })
 
-let hostedClient = null
-if (gqlBackupUri) {
-  hostedClient = new ApolloClient({
-    uri: gqlBackupUri,
-    cache: new InMemoryCache()
-  })
+let hostedClient: ApolloClient<NormalizedCacheObject> | null = null
+export const getBackupClient = () => {
+  if (hostedClient) {
+    return hostedClient
+  } else if (gqlBackupUri) {
+    hostedClient = new ApolloClient({
+      uri: gqlBackupUri,
+      cache: new InMemoryCache()
+    })
 
-  window.hostedClient = hostedClient
+    window.hostedClient = hostedClient
+    return hostedClient
+  }
+  return null
 }
 
 export const hasBackupClient = !!gqlBackupUri
-export const backupClient = hostedClient
 
 const aud = new Audius()
 window.aud = aud

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -12,11 +12,13 @@ import { State as ClaimsState } from 'store/cache/claims/slice'
 import { State as AnalyticsState } from 'store/cache/analytics/slice'
 import { State as MusicState } from 'store/cache/music/slice'
 import { State as RewardsState } from 'store/cache/rewards/slice'
+import { State as APIState } from 'store/api/slice'
 
 export type AppState = {
   router: RouterState
   pageHistory: PageHistoryState
   account: AccountState
+  api: APIState
   cache: {
     discoveryProvider: DiscoveryProviderState
     contentNode: ContentNodeState

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -28,6 +28,7 @@ export const withTimeout = async (
   return res
 }
 
+// TODO: put in env vars for staging
 export const fetchUntilSuccess = async (endpoints: string[]): Promise<any> => {
   const allowList = [
     'https://discoveryprovider.audius.co',


### PR DESCRIPTION
## Changes
* Update the prod env `REACT_APP_GQL_URI` to point at the graph mainnet gateway
* Add env var `REACT_APP_GQL_BACKUP_URI` to be used on the primary failing
* Add logic for switching graphql uri on primary failure
  * Adds slice to hold state for backup available and failure
  * Adds logic to switch apollo client provider on failure
  * wraps `useQuery` to watch for failures
  * Add logic to `useUser` and `useUsers` to try both graphql gateways before falling back to eth contract reads
* Updates `useUser` and `useUsers` graphql queries to get first 200 - fixes estimates for rewards
  * NOTE: This should later be changed to actually paginate 🙃 
  