### PR TITLE
Disable delegate btn when delegators has reached limit

### DIFF
--- a/src/components/UserInfo/UserInfo.tsx
+++ b/src/components/UserInfo/UserInfo.tsx
@@ -26,10 +26,10 @@ import { createStyles } from 'utils/mobile'
 import UserImage from 'components/UserImage'
 import Bounds from 'components/Bounds'
 import Tooltip, { Position } from 'components/Tooltip'
+import { useSelector } from 'react-redux'
+import { getDelegatorInfo } from 'store/cache/protocol/hooks'
 
 const styles = createStyles({ desktopStyles, mobileStyles })
-
-const DELEGATOR_LIMIT = 175
 
 const messages = {
   delegate: 'DELEGATE',
@@ -63,6 +63,7 @@ const UserInfo = ({
   const { name, wallet } = user
   const { isLoggedIn } = useAccount()
   const [isOpen, setIsOpen] = useState(false)
+  const { maxDelegators } = useSelector(getDelegatorInfo)
   const onClick = useCallback(() => setIsOpen(true), [setIsOpen])
   const onClose = useCallback(() => setIsOpen(false), [setIsOpen])
   const { hasClaim, status: claimStatus } = usePendingClaim(wallet)
@@ -131,7 +132,8 @@ const UserInfo = ({
     isLoggedIn && !isOwner && claimStatus === Status.Success && hasClaim
 
   const isClaimDisabled = !isValidBounds
-  const isDelegatorLimitReached = (user as Operator)?.delegators?.length >= DELEGATOR_LIMIT
+  const isDelegatorLimitReached = maxDelegators !== undefined &&
+    (user as Operator)?.delegators?.length >= maxDelegators
 
   return (
     <>

--- a/src/components/UserInfo/UserInfo.tsx
+++ b/src/components/UserInfo/UserInfo.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useCallback, useEffect } from 'react'
-import Button from 'components/Button'
+import { useSelector } from 'react-redux'
 import clsx from 'clsx'
 
+import Button from 'components/Button'
 import Paper from 'components/Paper'
 import { ButtonType } from '@audius/stems'
 import DelegateStakeModal from 'components/DelegateStakeModal'
@@ -26,7 +27,6 @@ import { createStyles } from 'utils/mobile'
 import UserImage from 'components/UserImage'
 import Bounds from 'components/Bounds'
 import Tooltip, { Position } from 'components/Tooltip'
-import { useSelector } from 'react-redux'
 import { getDelegatorInfo } from 'store/cache/protocol/hooks'
 
 const styles = createStyles({ desktopStyles, mobileStyles })
@@ -132,7 +132,8 @@ const UserInfo = ({
     isLoggedIn && !isOwner && claimStatus === Status.Success && hasClaim
 
   const isClaimDisabled = !isValidBounds
-  const isDelegatorLimitReached = maxDelegators !== undefined &&
+  const isDelegatorLimitReached =
+    maxDelegators !== undefined &&
     (user as Operator)?.delegators?.length >= maxDelegators
 
   return (

--- a/src/components/UserInfo/UserInfo.tsx
+++ b/src/components/UserInfo/UserInfo.tsx
@@ -29,12 +29,15 @@ import Tooltip, { Position } from 'components/Tooltip'
 
 const styles = createStyles({ desktopStyles, mobileStyles })
 
+const DELEGATOR_LIMIT = 175
+
 const messages = {
   delegate: 'DELEGATE',
   undelegate: 'UNDELEGATE',
   claim: 'CLAIM',
   makeClaim: 'Make Claim',
-  claimOutOfBounds: 'Total stake out of bounds'
+  claimOutOfBounds: 'Total stake out of bounds',
+  delegatorLimitReached: 'This operator has reached its delegator limit'
 }
 
 type UserInfoProps = {
@@ -128,16 +131,24 @@ const UserInfo = ({
     isLoggedIn && !isOwner && claimStatus === Status.Success && hasClaim
 
   const isClaimDisabled = !isValidBounds
+  const isDelegatorLimitReached = (user as Operator)?.delegators?.length >= DELEGATOR_LIMIT
 
   return (
     <>
       {showDelegate && (
         <div className={styles.buttonContainer}>
-          <Button
-            text={messages.delegate}
-            type={ButtonType.PRIMARY}
-            onClick={onClick}
-          />
+          <Tooltip
+            position={Position.TOP}
+            text={messages.delegatorLimitReached}
+            isDisabled={!isDelegatorLimitReached}
+          >
+            <Button
+              text={messages.delegate}
+              type={ButtonType.PRIMARY}
+              isDisabled={isDelegatorLimitReached}
+              onClick={onClick}
+            />
+          </Tooltip>
           <DelegateStakeModal
             serviceOperatorWallet={wallet}
             isOpen={isOpen}
@@ -170,7 +181,6 @@ const UserInfo = ({
             position={Position.TOP}
             text={messages.claimOutOfBounds}
             isDisabled={!isClaimDisabled}
-            className={styles.claimDisabledTooltip}
           >
             <Button
               text={messages.claim}


### PR DESCRIPTION
Four test cases:

Delegator limit reached
![Screen Shot 2021-07-06 at 7 00 20 PM](https://user-images.githubusercontent.com/2731362/124689454-67e8d800-de8d-11eb-8916-a3cf9bac8465.png)

Delegator limit not reached
![Screen Shot 2021-07-06 at 7 06 44 PM](https://user-images.githubusercontent.com/2731362/124689463-6b7c5f00-de8d-11eb-8f74-1b885abf6696.png)

Delegator limit reached, but already delegated
![Screen Shot 2021-07-06 at 7 06 50 PM](https://user-images.githubusercontent.com/2731362/124689466-6d462280-de8d-11eb-9c85-a855808bd1e6.png)

Regular user (no delegate option)
![Screen Shot 2021-07-06 at 7 06 53 PM](https://user-images.githubusercontent.com/2731362/124689475-6f0fe600-de8d-11eb-9891-b98e2319f21c.png)
