### PR TITLE
Bump resource size

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,6 +79,7 @@ jobs:
     working_directory: ~/protocol-dashboard
     docker:
       - image: circleci/node:10.13
+    resource_class: large
     steps:
       - attach_workspace:
           at: ./
@@ -126,6 +127,7 @@ jobs:
     working_directory: ~/protocol-dashboard
     docker:
       - image: circleci/node:10.13
+    resource_class: large
     steps:
       - checkout
       - attach_workspace:

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "start:dev": "npm run configure-local-env && env-cmd -f .env.development.local npm start",
     "start:stage": "env-cmd -f .env.stage npm start",
     "start:prod": "env-cmd -f .env.prod npm start",
-    "build": "react-scripts build",
+    "build": "react-scripts --max_old_space_size=8192 build",
     "build:stage": "env-cmd -f .env.stage npm run build && node ./scripts/rerouteLegacy.js stage",
     "build:prod": "env-cmd -f .env.prod npm run build && node ./scripts/rerouteLegacy.js",
     "test": "react-scripts test",


### PR DESCRIPTION
Bump CI resource size to large
Bump script build size to 8GB
* This now matches the audius-client build