### PR TITLE
Fix spMinDelegation logic check

### DIFF
--- a/src/store/cache/user/graph/formatter.ts
+++ b/src/store/cache/user/graph/formatter.ts
@@ -53,7 +53,7 @@ export const formatUser = async (
     userWallet
   )
   // Prefer min delegation amount if provided and greater than protocol wide amount
-  if (spMinDelegationAmount) {
+  if (!spMinDelegationAmount.isZero()) {
     if (
       minDelegationAmount === null ||
       spMinDelegationAmount.gt(minDelegationAmount)

--- a/src/store/cache/user/hooks.ts
+++ b/src/store/cache/user/hooks.ts
@@ -149,7 +149,7 @@ const getServiceProviderMetadata = async (
     wallet
   )
   // Prefer min delegation amount if provided and greater than protocol wide amount
-  if (spMinDelegationAmount) {
+  if (!spMinDelegationAmount.isZero()) {
     if (
       minDelegationAmount === null ||
       spMinDelegationAmount.gt(minDelegationAmount)


### PR DESCRIPTION
Things were not working here because spMinDelegationAmount is always defined, when it is unset, the value is 0, so instead we should check for *no value*.

Tested:
- checked SP page without min set
- checked SP page with min set