### PR TITLE
Remove wait for all nodes on analytics

### DIFF
--- a/src/components/VerticalBarChart/VerticalBarChart.tsx
+++ b/src/components/VerticalBarChart/VerticalBarChart.tsx
@@ -107,7 +107,6 @@ const getOptions = (id: string, max: number) => ({
     yAlign: 'bottom',
     position: 'nearest',
     custom: function(tooltipModel: any) {
-      console.log({ tooltipModel })
       // Tooltip Element
       let tooltipEl = document.getElementById(`chartjs-tooltip-${id}`)
 
@@ -162,7 +161,6 @@ const getOptions = (id: string, max: number) => ({
     },
     callbacks: {
       title: (tooltipItem: any, data: any) => {
-        console.log({ tooltipItem })
         return { value: parseInt(tooltipItem[0].value) }
       }
     }

--- a/src/store/cache/music/hooks.ts
+++ b/src/store/cache/music/hooks.ts
@@ -26,11 +26,15 @@ export const getTopAlbums = (state: AppState) => state.cache.music.topAlbums
 
 // -------------------------------- Thunk Actions  ---------------------------------
 
-export function fetchTopTracks(
-  nodes: DiscoveryProvider[]
-): ThunkAction<void, AppState, Audius, Action<string>> {
-  return async (dispatch, getState, aud) => {
+export function fetchTopTracks(): ThunkAction<
+  void,
+  AppState,
+  Audius,
+  Action<string>
+> {
+  return async (dispatch, _, aud) => {
     try {
+      await aud.awaitSetup()
       const data = await fetchWithLibs({
         endpoint: '/v1/tracks/trending',
         queryParams: { limit: 4 }
@@ -50,11 +54,15 @@ export function fetchTopTracks(
   }
 }
 
-export function fetchTopPlaylists(
-  nodes: DiscoveryProvider[]
-): ThunkAction<void, AppState, Audius, Action<string>> {
-  return async (dispatch, getState, aud) => {
+export function fetchTopPlaylists(): ThunkAction<
+  void,
+  AppState,
+  Audius,
+  Action<string>
+> {
+  return async (dispatch, _, aud) => {
     try {
+      await aud.awaitSetup()
       const limit = 5
       const data = await fetchWithLibs({
         endpoint: '/v1/full/playlists/trending'
@@ -74,11 +82,15 @@ export function fetchTopPlaylists(
   }
 }
 
-export function fetchTopAlbums(
-  nodes: DiscoveryProvider[]
-): ThunkAction<void, AppState, Audius, Action<string>> {
-  return async (dispatch, getState, aud) => {
+export function fetchTopAlbums(): ThunkAction<
+  void,
+  AppState,
+  Audius,
+  Action<string>
+> {
+  return async (dispatch, _, aud) => {
     try {
+      await aud.awaitSetup()
       const data = await fetchWithLibs({
         endpoint: '/v1/playlists/top',
         queryParams: { type: 'album', limit: 5 }
@@ -103,15 +115,14 @@ export function fetchTopAlbums(
 export const useTopTracks = () => {
   const [doOnce, setDoOnce] = useState(false)
   const topTracks = useSelector(getTopTracks)
-  const { nodes } = useDiscoveryProviders({})
   const dispatch = useDispatch()
 
   useEffect(() => {
-    if (!doOnce && nodes[0] && !topTracks) {
+    if (!doOnce && !topTracks) {
       setDoOnce(true)
-      dispatch(fetchTopTracks(nodes))
+      dispatch(fetchTopTracks())
     }
-  }, [doOnce, topTracks, dispatch, nodes])
+  }, [doOnce, topTracks, dispatch])
 
   useEffect(() => {
     if (topTracks) {
@@ -125,15 +136,14 @@ export const useTopTracks = () => {
 export const useTopPlaylists = () => {
   const [doOnce, setDoOnce] = useState(false)
   const topPlaylists = useSelector(getTopPlaylists)
-  const { nodes } = useDiscoveryProviders({})
   const dispatch = useDispatch()
 
   useEffect(() => {
-    if (!doOnce && nodes[0] && !topPlaylists) {
+    if (!doOnce && !topPlaylists) {
       setDoOnce(true)
-      dispatch(fetchTopPlaylists(nodes))
+      dispatch(fetchTopPlaylists())
     }
-  }, [topPlaylists, dispatch, nodes, doOnce])
+  }, [topPlaylists, dispatch, doOnce])
 
   useEffect(() => {
     if (topPlaylists) {
@@ -147,15 +157,14 @@ export const useTopPlaylists = () => {
 export const useTopAlbums = () => {
   const [doOnce, setDoOnce] = useState(false)
   const topAlbums = useSelector(getTopAlbums)
-  const { nodes } = useDiscoveryProviders({})
   const dispatch = useDispatch()
 
   useEffect(() => {
-    if (!doOnce && nodes[0] && !topAlbums) {
+    if (!doOnce && !topAlbums) {
       setDoOnce(true)
-      dispatch(fetchTopAlbums(nodes))
+      dispatch(fetchTopAlbums())
     }
-  }, [topAlbums, dispatch, nodes, doOnce])
+  }, [topAlbums, dispatch, doOnce])
 
   useEffect(() => {
     if (topAlbums) {

--- a/src/store/cache/protocol/hooks.ts
+++ b/src/store/cache/protocol/hooks.ts
@@ -88,12 +88,14 @@ export function fetchEthBlockNumber(): ThunkAction<
   Action<string>
 > {
   return async (dispatch, getState, aud) => {
-    setInterval(async () => {
+    const updateEthBlockNumber = async () => {
       if (isWindowActive) {
         const ethBlockNumber = await aud.getEthBlockNumber()
         dispatch(setEthBlockNumber(ethBlockNumber))
       }
-    }, 10000)
+    }
+    await updateEthBlockNumber()
+    setInterval(updateEthBlockNumber, 10000)
   }
 }
 


### PR DESCRIPTION
## Summary
* Removes unnecessary console.logs
* Fixes `fetchEthBlockNumber`
  * The problem with this is that it was calling in a setInterval and not called initially, so the client would have to wait 10 seconds before the eth block number was set. Thus, causing an analytics chart to not load. 
  * Additionally, because it only updated if the window is active, if it was in view but not active then the chart would never load and looks like a bug
* Removes the hook `const { nodes } = useDiscoveryProviders({})` in the analytics and fetch top tracks/playlists/albums/genres/apps/apis etc. because we only fetch from a single discovery node using libs. it's replaced with `await aud.awaitSetup()` to ensure libs is setup and a discovery node is selected before making the request. 


Fixes PLAT-137