### PR TITLE
Update fetch metadata to only get location and version

### DIFF
--- a/src/services/Audius/AudiusClient.ts
+++ b/src/services/Audius/AudiusClient.ts
@@ -18,7 +18,8 @@ import {
   displayShortAud,
   getAud,
   getWei,
-  getNodeMetadata,
+  getDiscoveryNodeMetadata,
+  getContentNodeMetadata,
   getEthWallet,
   getBlock,
   getBlockNearTimestamp,
@@ -86,7 +87,8 @@ export class AudiusClient {
   static displayShortAud = displayShortAud
   static getAud = getAud
   static getWei = getWei
-  static getNodeMetadata = getNodeMetadata
+  static getDiscoveryNodeMetadata = getDiscoveryNodeMetadata
+  static getContentNodeMetadata = getContentNodeMetadata
 }
 
 window.AudiusClient = AudiusClient

--- a/src/services/Audius/helpers.ts
+++ b/src/services/Audius/helpers.ts
@@ -133,6 +133,9 @@ type NodeMetadata = {
   country: string
 }
 
+/**
+ * @deprecated Replaced with methods below. Can be removed after all nodes update to version 0.3.58
+ */
 export async function getNodeMetadata(endpoint: string): Promise<NodeMetadata> {
   try {
     const { data } = await fetchWithTimeout(
@@ -144,5 +147,34 @@ export async function getNodeMetadata(endpoint: string): Promise<NodeMetadata> {
     console.error(e)
     // Return no version if we couldn't find one, so we don't hold everything up
     return { version: '', country: '' }
+  }
+}
+
+export async function getDiscoveryNodeMetadata(
+  endpoint: string
+): Promise<NodeMetadata> {
+  try {
+    const {
+      data: { country },
+      version: { version }
+    } = await fetchWithTimeout(`${endpoint}/location?verbose=true`)
+    return { version, country }
+  } catch (e) {
+    // Try legacy method:
+    return await getNodeMetadata(endpoint)
+  }
+}
+
+export async function getContentNodeMetadata(
+  endpoint: string
+): Promise<NodeMetadata> {
+  try {
+    const {
+      data: { country, version }
+    } = await fetchWithTimeout(`${endpoint}/version`)
+    return { version, country }
+  } catch (e) {
+    // Try legacy method:
+    return await getNodeMetadata(endpoint)
   }
 }

--- a/src/store/cache/contentNode/hooks.ts
+++ b/src/store/cache/contentNode/hooks.ts
@@ -67,7 +67,9 @@ export const getFilteredNodes = ({
 // -------------------------------- Helpers  --------------------------------
 
 const processNode = async (node: Node, aud: Audius): Promise<ContentNode> => {
-  const { country, version } = await Audius.getNodeMetadata(node.endpoint)
+  const { country, version } = await Audius.getContentNodeMetadata(
+    node.endpoint
+  )
   const isDeregistered = node.endpoint === ''
   let previousInfo = {}
   if (isDeregistered) {

--- a/src/store/cache/discoveryProvider/hooks.ts
+++ b/src/store/cache/discoveryProvider/hooks.ts
@@ -71,7 +71,9 @@ const processDP = async (
   node: Node,
   aud: Audius
 ): Promise<DiscoveryProvider> => {
-  const { version, country } = await Audius.getNodeMetadata(node.endpoint)
+  const { version, country } = await Audius.getDiscoveryNodeMetadata(
+    node.endpoint
+  )
   const isDeregistered = node.endpoint === ''
   let previousInfo = {}
   if (isDeregistered) {


### PR DESCRIPTION
## Summary
Update the fetch node metadata to only fetch location instead of entirety of health check
Falls back to legacy method of fetching location with health check

Discovery Node changes for endpoint ref: https://github.com/AudiusProject/audius-protocol/pull/3101

Tested running against new discovery changes with endpoint and legacy against prod and it worked!

Closes PLAT-138