### PR TITLE
Fix sp with no registered services and leftover delegators

### DIFF
--- a/src/containers/User/User.tsx
+++ b/src/containers/User/User.tsx
@@ -137,7 +137,7 @@ const UserPage: React.FC<UserPageProps> = (props: UserPageProps) => {
             <DelegationStatsChip
               className={styles.delegationState}
               deployerCut={
-                (user as Operator | undefined)?.serviceProvider.deployerCut ?? 0
+                (user as Operator | undefined)?.serviceProvider?.deployerCut ?? 0
               }
               delegated={inboundDelegation.amount ?? Utils.toBN('0')}
               minDelegation={
@@ -145,7 +145,7 @@ const UserPage: React.FC<UserPageProps> = (props: UserPageProps) => {
                 Utils.toBN('0')
               }
               delegators={
-                (user as Operator | undefined)?.delegators.length ?? 0
+                (user as Operator | undefined)?.delegators?.length ?? 0
               }
               isLoading={status === Status.Loading}
             />
@@ -178,7 +178,7 @@ const UserPage: React.FC<UserPageProps> = (props: UserPageProps) => {
         wallet={user?.wallet}
         timelineType={isServiceProvider ? 'ServiceProvider' : 'Delegator'}
       />
-      {isServiceProvider && (user as Operator).delegators.length > 0 && (
+      {(user as Operator)?.delegators?.length > 0 && (
         <DelegatorsTable
           wallet={user.wallet}
           className={styles.delegatorsContainer}

--- a/src/store/cache/user/graph/formatter.ts
+++ b/src/store/cache/user/graph/formatter.ts
@@ -35,7 +35,7 @@ export const formatUser = async (
       : { amount: new BN(0), lockupExpiryBlock: 0, target: '' }
   }
 
-  if (user.services.length === 0 && user.stakeAmount === '0')
+  if (user.services.length === 0 && user.stakeAmount === '0' && user.claimableDelegationReceivedAmount === '0')
     return formattedUser
 
   // Note: We must make a contract call to check "validBounds" because that value is not

--- a/src/store/cache/user/hooks.ts
+++ b/src/store/cache/user/hooks.ts
@@ -285,8 +285,8 @@ export function fetchUser(
     if (setStatus) setStatus(Status.Loading)
     const user = await getUserMetadata(wallet, aud)
 
-    const isStaker = await aud.Staking.isStaker(wallet)
-    if (!isStaker) {
+    const totalStaked = await aud.Staking.totalStakedFor(wallet)
+    if (!totalStaked.gt(new BN('0'))) {
       dispatch(
         setUsers({
           users: { [wallet]: user }


### PR DESCRIPTION
The protocol dashboard currently errors on pages for old services providers that have deregistered their nodes.
This change fixes that error and also updates the `isServiceProvider` bool to also check for delegators to allow the page to render as a service provider and let the delegators un-delegate

Fixes PLAT-288