### PR TITLE
Hotfix CI img install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ jobs:
           at: ./
       - run:
           name: install deps
-          command: sudo apt install libsecret-1-0
+          command: sudo apt update && sudo apt install -y libsecret-1-0
       - run:
           name: armada publish
           command: |


### PR DESCRIPTION
Fixes failing `deploy-staging` CI job, which is caused by changing to the next-gen CircleCI image ([this one-liner](https://github.com/AudiusProject/protocol-dashboard/pull/152/files#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47R83)). See https://circleci.com/docs/next-gen-migration-guide/#troubleshooting.