### PR TITLE
Use relative paths for IPFS

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,10 +3,10 @@
 
 <head>
   <meta charset="utf-8" />
-  <link rel="shortcut icon" href="/favicon.ico" />
+  <link rel="shortcut icon" href="favicon.ico" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="theme-color" content="#CC0FE0" />
-  <link rel="manifest" href="/manifest.json" />
+  <link rel="manifest" href="manifest.json" />
 
   <script src="https://cdn.jsdelivr.net/npm/web3@legacy/dist/web3.min.js"></script>
 
@@ -26,7 +26,7 @@
 <body>
   <noscript>You need to enable JavaScript to run this app.</noscript>
   <div id="root"></div>
-  <script type="module" src="/src/index.tsx"></script>
+  <script type="module" src="src/index.tsx"></script>
 </body>
 
 </html>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,7 @@ import wasm from 'vite-plugin-wasm'
 import topLevelAwait from 'vite-plugin-top-level-await'
 
 export default defineConfig({
+  base: './',
   plugins: [
     react(),
     wasm(),


### PR DESCRIPTION
Stage deploy worked with Armada, but on prod the IPFS link is unable to serve the files because it's in a relative path (ie, `/ipfs/<cid>`). `npm run start:prod` works, along with `npm run build:prod && npm run serve`.